### PR TITLE
[IMP] website_snippet_code: width of snippet

### DIFF
--- a/website_snippet_code/__manifest__.py
+++ b/website_snippet_code/__manifest__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for full copyright and licensing details.
 {
     'name': "Website Snippet Code",
-    'version': '1.0.0',
+    'version': '1.1.0',
     'summary': 'Highlight code in many languages',
     'license': 'LGPL-3',
     'author': "Andrius Laukavičius",

--- a/website_snippet_code/views/snippet_templates.xml
+++ b/website_snippet_code/views/snippet_templates.xml
@@ -4,8 +4,10 @@
         <section class="o_website_snippet_code auto">
             <div class="container">
                 <div class="row">
-                    <pre class="o_website_snippet_code_raw">def test():
+                    <div class="col-lg-10 offset-lg-1">
+                        <pre class="o_website_snippet_code_raw">def test():
     pass</pre>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Wrapped `pre` element with additional `div` element, that contains
classes to allow adjusting width of block of code.
Using defaults as `col-lg-10 offset-lg-1` to have same width and
alignment as a text of block (for easier matching between text and
code).

[BRANCH] feature/code-snippet-width