### PR TITLE
[FIX] website_snippet_code: br -> \n when highlight

### DIFF
--- a/website_snippet_code/__manifest__.py
+++ b/website_snippet_code/__manifest__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for full copyright and licensing details.
 {
     'name': "Website Snippet Code",
-    'version': '1.1.0',
+    'version': '1.1.1',
     'summary': 'Highlight code in many languages',
     'license': 'LGPL-3',
     'author': "Andrius Laukavičius",

--- a/website_snippet_code/static/src/js/snippet_code_highlight.js
+++ b/website_snippet_code/static/src/js/snippet_code_highlight.js
@@ -65,13 +65,20 @@ odoo.define('website_snippet_code.code_highlight', function () {
         return $(getHtmlForHighlight(pre_raw, used_classes))
     }
 
+    function replaceBrWithNewLine(str){
+        return str.replace(/<br[^>]*>/gi, '\n')
+    }
+
     function highlight($pre_raw, $pre_hl){
+        // Replace br with \n, because br element is incorrectly
+        // interpreted when highlighting.
+        var html_str_to_hl = replaceBrWithNewLine($pre_hl.html());
+        $pre_hl.html(html_str_to_hl);
         $pre_raw.hide();
         $pre_hl.insertAfter($pre_raw[0]);
         hljs.highlightBlock($pre_hl[0]);
     }
     $(document).ready(function() {
-
         var snippets = $('.o_website_snippet_code');
         snippets.each(function(i, snippet){
             var $snippet = $(snippet);
@@ -101,6 +108,7 @@ odoo.define('website_snippet_code.code_highlight', function () {
             getClassesForHighlight: getClassesForHighlight,
             getHtmlForHighlight: getHtmlForHighlight,
             createElementForHighlight: createElementForHighlight,
+            replaceBrWithNewLine: replaceBrWithNewLine,
             highlight: highlight,
         }
     }

--- a/website_snippet_code/static/tests/website_snippet_code_tests.js
+++ b/website_snippet_code/static/tests/website_snippet_code_tests.js
@@ -11,6 +11,7 @@ QUnit.module('website_snippet_code', {
         this.getClassForHighlight = functions.getClassForHighlight;
         this.copyItems = functions.copyItems;
         this.createElementForHighlight = functions.createElementForHighlight;
+        this.replaceBrWithNewLine = functions.replaceBrWithNewLine
         this.highlight = functions.highlight;
         this.pre_raw_outer_html = `<pre class="`+`
         ${CodeHighlight['CLASS_CODE_RAW']}">def test():
@@ -85,6 +86,22 @@ QUnit.test("Copy items: full exclusion", function (assert) {
         this.copyItems(['a', 'b'], ['a', 'b']), []);
     assert.deepEqual(
         this.copyItems(['a', 'b', 'c'], ['a', 'b', 'c']), []);
+});
+
+QUnit.test("replace br element with \n", function (assert) {
+    assert.expect(4);
+    var s1 = '<pre><code>x = 10<code></pre>';
+    var s2 = '<pre><code>x = 10\n<code></pre>';
+    var s3 = '<pre><code>x = 10<br><code></pre>';
+    var s4 = '<pre><code>\nx = 10<br><br/><br class="test"/><code></pre>';
+    var res_s1 = this.replaceBrWithNewLine(s1);
+    assert.strictEqual(res_s1, s1)
+    var res_s2 = this.replaceBrWithNewLine(s2);
+    assert.strictEqual(res_s2, s2)
+    var res_s3 = this.replaceBrWithNewLine(s3);
+    assert.strictEqual(res_s3, '<pre><code>x = 10\n<code></pre>')
+    var res_s4 = this.replaceBrWithNewLine(s4);
+    assert.strictEqual(res_s4, '<pre><code>\nx = 10\n\n\n<code></pre>')
 });
 
 QUnit.test("createElementForHighlight: extra class copied", function (assert) {


### PR DESCRIPTION
`br` element in `pre code` elements is incorrectly highlighted. For
example if code comment line is added, any code below comment line is
also interpreted as comment, thus getting incorrect highlighting.

[BRANCH] bugfix/snippet-code-newline-ala