### PR TITLE
[ADD] delivery_hs_code_country: init

### DIFF
--- a/base_eori/README.rst
+++ b/base_eori/README.rst
@@ -1,0 +1,9 @@
+EORI Number
+###########
+
+Adds EORI (Economic Operators Registration and Identification) number on partner and company.
+
+Contributors
+============
+
+* Andrius Laukavičius (timefordev)

--- a/base_eori/__init__.py
+++ b/base_eori/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+__all__ = [models]

--- a/base_eori/__manifest__.py
+++ b/base_eori/__manifest__.py
@@ -1,0 +1,18 @@
+# Author: Andrius Laukavičius. Copyright: Andrius Laukavičius.
+# See LICENSE file for full copyright and licensing details.
+{
+    'name': 'EORI Number',
+    'version': '12.0.1.0.0',
+    'summary': 'eori, partner, company',
+    'license': 'LGPL-3',
+    'author': 'Andrius Laukavičius',
+    'website': 'https://timefordev.com',
+    'category': 'Extra Tools',
+    'depends': [
+        'base'
+    ],
+    'data': [
+        'views/res_company_views.xml',
+        'views/res_partner_views.xml',
+    ],
+}

--- a/base_eori/i18n/lt.po
+++ b/base_eori/i18n/lt.po
@@ -1,0 +1,40 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* base_eori
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-18 16:48+0000\n"
+"PO-Revision-Date: 2021-05-18 16:48+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: base_eori
+#: model:ir.model,name:base_eori.model_res_company
+msgid "Companies"
+msgstr "Įmonės"
+
+#. module: base_eori
+#: model:ir.model,name:base_eori.model_res_partner
+msgid "Contact"
+msgstr "Kontaktai"
+
+#. module: base_eori
+#: model:ir.model.fields,field_description:base_eori.field_res_company__eori
+#: model:ir.model.fields,field_description:base_eori.field_res_partner__eori
+#: model:ir.model.fields,field_description:base_eori.field_res_users__eori
+msgid "EORI"
+msgstr ""
+
+#. module: base_eori
+#: model:ir.model.fields,help:base_eori.field_res_company__eori
+#: model:ir.model.fields,help:base_eori.field_res_partner__eori
+#: model:ir.model.fields,help:base_eori.field_res_users__eori
+msgid "Economic Operators Registration and Identification number"
+msgstr "Ūkio subjektų registracijos ir identifikavimo numeris"

--- a/base_eori/models/__init__.py
+++ b/base_eori/models/__init__.py
@@ -1,0 +1,2 @@
+from . import res_partner, res_company
+__all__ = [res_partner, res_company]

--- a/base_eori/models/res_company.py
+++ b/base_eori/models/res_company.py
@@ -1,0 +1,9 @@
+from odoo import models, fields
+
+
+class ResCompany(models.Model):
+    """Extend to eori related field."""
+
+    _inherit = 'res.company'
+
+    eori = fields.Char(related='partner_id.eori', readonly=False)

--- a/base_eori/models/res_partner.py
+++ b/base_eori/models/res_partner.py
@@ -1,0 +1,17 @@
+from odoo import models, fields, api
+
+
+class ResPartner(models.Model):
+    """Extend to eori field."""
+
+    _inherit = 'res.partner'
+
+    eori = fields.Char(
+        string="EORI",
+        help="Economic Operators Registration and Identification number"
+    )
+
+    @api.model
+    def _commercial_fields(self):
+        """Extend to add eori field."""
+        return super()._commercial_fields() + ['eori']

--- a/base_eori/tests/__init__.py
+++ b/base_eori/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_eori
+__all__ = [test_eori]

--- a/base_eori/tests/test_eori.py
+++ b/base_eori/tests/test_eori.py
@@ -1,0 +1,29 @@
+from odoo.tests.common import SavepointCase
+
+
+class TestEori(SavepointCase):
+    """Class to test EORI number field."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up data for eori tests."""
+        super().setUpClass()
+        cls.ResCompany = cls.env['res.company']
+        cls.partner_azure = cls.env.ref('base.res_partner_12')
+        cls.partner_azure_freeman = cls.env.ref('base.res_partner_address_15')
+
+    def test_01_company_eori(self):
+        """Create company to set EORI on related partner."""
+        company = self.ResCompany.create(
+            {'name': 'New Company 123', 'eori': 'E12345'}
+        )
+        self.assertEqual(company.partner_id.eori, company.eori)
+        self.assertEqual(company.eori, 'E12345')
+
+    def test_02_partner_eori(self):
+        """Set EORI on commercial partner to sync with contacts."""
+        self.partner_azure.eori = 'E54321'
+        self.assertEqual(
+            self.partner_azure_freeman.eori, self.partner_azure.eori
+        )
+        self.assertEqual(self.partner_azure_freeman.eori, 'E54321')

--- a/base_eori/views/res_company_views.xml
+++ b/base_eori/views/res_company_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_company_form_inherit" model="ir.ui.view">
+        <field name="name">res.company.form.eori</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <field name="vat" position="after">
+                <field name="eori"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/base_eori/views/res_partner_views.xml
+++ b/base_eori/views/res_partner_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_partner_form_inherit" model="ir.ui.view">
+        <field name="name">res.partner.form.eori</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+            <field name="vat" position="after">
+                <field
+                    name="eori"
+                    attrs="{'readonly': [('parent_id', '!=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/delivery_hs_code_country/README.rst
+++ b/delivery_hs_code_country/README.rst
@@ -1,0 +1,11 @@
+Delivery HS Code per Country
+############################
+
+Product Harmonized System Codes first six number must be the same, but remaining numbers can be different per country.
+
+This module allows to specify remaining part of code per country on products. Can also mark origin country.
+
+Contributors
+============
+
+* Andrius Laukavičius (timefordev)

--- a/delivery_hs_code_country/__init__.py
+++ b/delivery_hs_code_country/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+__all__ = [models]

--- a/delivery_hs_code_country/__manifest__.py
+++ b/delivery_hs_code_country/__manifest__.py
@@ -1,0 +1,18 @@
+# Author: Andrius Laukavičius. Copyright: Andrius Laukavičius.
+# See LICENSE file for full copyright and licensing details.
+{
+    'name': "Delivery HS Code per Country",
+    'version': '12.0.1.0.0',
+    'summary': 'delivery, harmonized code, origin country, countries',
+    'license': 'LGPL-3',
+    'author': "Andrius Laukavičius",
+    'website': "https://timefordev.com",
+    'category': 'Warehouse',
+    'depends': [
+        'delivery_hs_code'
+    ],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/product_template_views.xml',
+    ],
+}

--- a/delivery_hs_code_country/i18n/lt.po
+++ b/delivery_hs_code_country/i18n/lt.po
@@ -1,0 +1,98 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* delivery_hs_code_country
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-16 15:01+0000\n"
+"PO-Revision-Date: 2021-05-16 15:01+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__country_id
+msgid "Country"
+msgstr "Šalis"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__name
+msgid "Country HS Code"
+msgstr "Šalies HS kodas"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__create_uid
+msgid "Created by"
+msgstr "Sukūrė"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__create_date
+msgid "Created on"
+msgstr "Sukurta"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__display_name
+msgid "Display Name"
+msgstr "Rodomas pavadinimas"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_product__hs_code_ids
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template__hs_code_ids
+msgid "HS Codes"
+msgstr "HS kodai"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__id
+msgid "ID"
+msgstr ""
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__is_origin_country
+msgid "Country of Origin"
+msgstr "Kilmės šalis"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code____last_update
+msgid "Last Modified on"
+msgstr "Paskutinį kartą keista"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__write_uid
+msgid "Last Updated by"
+msgstr "Paskutinį kartą atnaujino"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__write_date
+msgid "Last Updated on"
+msgstr "Paskutinį kartą atnaujinta"
+
+#. module: delivery_hs_code_country
+#: model:ir.model,name:delivery_hs_code_country.model_product_product
+msgid "Product"
+msgstr "Produktas"
+
+#. module: delivery_hs_code_country
+#: model:ir.model,name:delivery_hs_code_country.model_product_template
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__product_tmpl_id
+msgid "Product Template"
+msgstr "Produkto šablonas"
+
+#. module: delivery_hs_code_country
+#: model:ir.model,name:delivery_hs_code_country.model_product_template_hs_code
+msgid "Product Template HS Code"
+msgstr "Produkto šablono HS kodas"
+
+#. module: delivery_hs_code_country
+#: model:ir.model.fields,field_description:delivery_hs_code_country.field_product_template_hs_code__code
+msgid "Suffix"
+msgstr "Priešdėlis"
+
+#. module: delivery_hs_code_country
+#: sql_constraint:product.template.hs.code:0
+msgid "The country must be unique per related product template !"
+msgstr "Šalis privalo būti unikali pagal susijusį produkto šabloną !"

--- a/delivery_hs_code_country/models/__init__.py
+++ b/delivery_hs_code_country/models/__init__.py
@@ -1,0 +1,2 @@
+from . import product_template, product_product, product_template_hs_code
+__all__ = [product_template, product_product, product_template_hs_code]

--- a/delivery_hs_code_country/models/product_product.py
+++ b/delivery_hs_code_country/models/product_product.py
@@ -1,0 +1,31 @@
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    """Extend to add retrieve_hs_code method."""
+
+    _inherit = 'product.product'
+
+    def retrieve_hs_code(self, country_code=None):
+        """Retrieve related HS code for country or fallback to default.
+
+        If country is not specified or can't find code for specific
+        country, will fallback to origin country HS code or to HS code
+        specified directly on product.template.
+
+        Args:
+            country_code (str): country code to use in search
+                (default: {None}).
+
+        Returns:
+            HS Code.
+            str
+
+        """
+        # Case for convenience.
+        if not self:
+            return False
+        self.ensure_one()
+        return self.product_tmpl_id._retrieve_hs_code(
+            country_code=country_code
+        )

--- a/delivery_hs_code_country/models/product_template.py
+++ b/delivery_hs_code_country/models/product_template.py
@@ -1,0 +1,45 @@
+import re
+
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+HS_CODE_RE = r'^\d{6}$'
+
+
+class ProductTemplate(models.Model):
+    """Extend to relate with product.template.hs.code."""
+
+    _inherit = 'product.template'
+
+    hs_code_ids = fields.One2many(
+        'product.template.hs.code',
+        'product_tmpl_id',
+        string="HS Codes",
+    )
+    country_origin_id = fields.Many2one(
+        'res.country',
+        compute='_compute_country_origin_id',
+        string="Country of Origin",
+        store=True,
+    )
+
+    @api.depends('hs_code_ids.country_id', 'hs_code_ids.is_origin_country')
+    def _compute_country_origin_id(self):
+        for tmpl in self:
+            hs = tmpl.hs_code_ids.filtered(lambda r: r.is_origin_country)[:1]
+            tmpl.country_origin_id = hs.country_id
+
+    @api.constrains('hs_code')
+    def _check_hs_code(self):
+        msg = _("HS Code must be 6 digits. Got '%s' instead")
+        for tmpl in self.filtered('hs_code_ids'):
+            hs_code = tmpl.hs_code
+            if not hs_code or not re.match(HS_CODE_RE, hs_code):
+                raise ValidationError(msg % hs_code)
+
+    def _retrieve_hs_code(self, country_code=None):
+        self.ensure_one()
+        hs = self.hs_code_ids._filter_hs_code(country_code=country_code)
+        if not hs:
+            return self.hs_code
+        return hs.name

--- a/delivery_hs_code_country/models/product_template_hs_code.py
+++ b/delivery_hs_code_country/models/product_template_hs_code.py
@@ -1,0 +1,74 @@
+import re
+
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+
+HS_COUNTRY_CODE_RE = r'^\d+$'
+
+
+class ProductTemplateHsCode(models.Model):
+    """Model to store different HS code parts per country."""
+
+    _name = 'product.template.hs.code'
+    _description = "Product Template HS Code"
+
+    name = fields.Char(
+        compute='_compute_name', string="Country HS Code", store=True
+    )
+    code = fields.Char("Suffix")
+    product_tmpl_id = fields.Many2one(
+        'product.template',
+        string="Product Template",
+        required=True
+    )
+    country_id = fields.Many2one('res.country', required=True)
+    is_origin_country = fields.Boolean(string="Country of Origin")
+
+    _sql_constraints = [
+        (
+            'country_id_uniq',
+            'unique (country_id, product_tmpl_id)',
+            "The country must be unique per related product template !",
+        )
+    ]
+
+    @api.depends('code', 'product_tmpl_id.hs_code')
+    def _compute_name(self):
+        for hs in self:
+            hs.name = '%s%s' % (
+                hs.product_tmpl_id.hs_code or '', hs.code or ''
+            )
+
+    @api.constrains('code')
+    def _check_country_hs_code(self):
+        for hs in self.filtered('code'):
+            if not re.match(HS_COUNTRY_CODE_RE, hs.code):
+                raise ValidationError(
+                    _("Country HS Code Part must be digits only. Got"
+                        " '%s' instead") % hs.code
+                )
+
+    @api.constrains('is_origin_country', 'product_tmpl_id')
+    def _check_is_origin_country(self):
+        for hs in self.filtered('is_origin_country'):
+            if len(
+                hs.product_tmpl_id.hs_code_ids.filtered('is_origin_country')
+            ) > 1:
+                raise ValidationError(
+                    _("Only one HS Code can have Origin Country!")
+                )
+
+    def _filter_hs_code_by_country(self, country_code):
+        return self.filtered(
+            lambda r: r.country_id.code.upper() == country_code.upper()
+        )
+
+    def _filter_hs_code(self, country_code=None):
+        hs_origin = self.filtered('is_origin_country')
+        if not country_code:
+            return hs_origin
+        hs_country = self._filter_hs_code_by_country(country_code)
+        if not hs_country:
+            return hs_origin
+        return hs_country

--- a/delivery_hs_code_country/security/ir.model.access.csv
+++ b/delivery_hs_code_country/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_template_hs_code_user,product_template_hs_code user,model_product_template_hs_code,base.group_user,1,0,0,0
+access_product_template_hs_code_sale_manager,product_template_hs_code sale_manager,model_product_template_hs_code,sales_team.group_sale_manager,1,1,1,0
+access_product_template_hs_code_stock_manager,product_template_hs_code stock_manager,model_product_template_hs_code,stock.group_stock_manager,1,1,1,1

--- a/delivery_hs_code_country/tests/__init__.py
+++ b/delivery_hs_code_country/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import test_hs_code_country
+__all__ = [test_hs_code_country]

--- a/delivery_hs_code_country/tests/test_hs_code_country.py
+++ b/delivery_hs_code_country/tests/test_hs_code_country.py
@@ -1,0 +1,169 @@
+from psycopg2 import IntegrityError
+
+from odoo.exceptions import ValidationError
+from odoo.tools import mute_logger
+from odoo.tests.common import SavepointCase
+
+
+class TestHsCodeCountry(SavepointCase):
+    """Test class for HS Code functionality per country."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up data for HS Code tests."""
+        super().setUpClass()
+        # Models.
+        cls.ProductProduct = cls.env['product.product']
+        cls.ProductTemplateHsCode = cls.env['product.template.hs.code']
+        # Templates/Products.
+        # Desk.
+        cls.product_template_desk = cls.env.ref(
+            'product.product_product_4_product_template'
+        )
+        cls.product_template_desk.hs_code = '123456'
+        cls.product_desk = cls.env.ref('product.product_product_4')
+        # Chair.
+        cls.product_chair = cls.env.ref('product.product_delivery_01')
+        cls.product_template_chair = cls.product_chair.product_tmpl_id
+        # Countries.
+        cls.country_lt = cls.env.ref('base.lt')
+        cls.country_us = cls.env.ref('base.us')
+        cls.country_fr = cls.env.ref('base.fr')
+        # HS Codes.
+        hs_codes = cls.ProductTemplateHsCode.create([
+            {
+                'country_id': cls.country_lt.id,
+                'product_tmpl_id': cls.product_template_desk.id,
+            },
+            {
+                'code': '777',
+                'country_id': cls.country_us.id,
+                'is_origin_country': True,
+                'product_tmpl_id': cls.product_template_desk.id,
+            },
+            {
+                'code': '888',
+                'country_id': cls.country_fr.id,
+                'product_tmpl_id': cls.product_template_desk.id,
+            },
+        ])
+        cls.hs_code_lt = hs_codes[0]
+        cls.hs_code_us = hs_codes[1]
+        cls.hs_code_fr = hs_codes[2]
+
+    def test_01_retrieve_hs_code(self):
+        """Retrieve HS code with country code specified (has HS codes).
+
+        Case 1: 'lt' code passed.
+        Case 2: 'us' code passed.
+        Case 3: 'fr' code passed.
+        Case 4: 'gb' code passed.
+
+        """
+        # Case 1.
+        hs_code = self.product_desk.retrieve_hs_code('lt')
+        self.assertEqual(self.product_desk.country_origin_id, self.country_us)
+        self.assertEqual(hs_code, '123456')
+        # Case 2.
+        hs_code = self.product_desk.retrieve_hs_code('US')
+        self.assertEqual(hs_code, '123456777')
+        # Case 3.
+        hs_code = self.product_desk.retrieve_hs_code('FR')
+        # If can't find, will default to origin country HS code.
+        self.assertEqual(hs_code, '123456888')
+        # Case 4.
+        hs_code = self.product_desk.retrieve_hs_code('Gb')
+        # If can't find, will default to origin country HS code.
+        self.assertEqual(hs_code, '123456777')
+
+    def test_02_retrieve_hs_code(self):
+        """Retrieve HS code with country code specified (no HS codes).
+
+        Case 1: no main HS code.
+        Case 2: has main HS code, 'us' code passed.
+        Case 3: has main HS code, 'fr' code passed.
+
+        """
+        # Case 1.
+        hs_code = self.product_chair.retrieve_hs_code('us')
+        self.assertEqual(hs_code, False)
+        # Case 2.
+        self.product_chair.hs_code = '147852'
+        hs_code = self.product_chair.retrieve_hs_code('fr')
+        self.assertEqual(hs_code, '147852')
+        # Case 3.
+        hs_code = self.product_chair.retrieve_hs_code('fr')
+        self.assertEqual(hs_code, '147852')
+
+    def test_03_retrieve_hs_code(self):
+        """Retrieve HS code with no code specified.
+
+        Case 1: has country HS codes.
+        Case 2: has only main HS code.
+        """
+        # Case 1.
+        hs_code = self.product_desk.retrieve_hs_code(False)
+        self.assertEqual(hs_code, '123456777')
+        # Case 2.
+        self.product_chair.hs_code = '987456'
+        hs_code = self.product_chair.retrieve_hs_code(False)
+        self.assertEqual(hs_code, '987456')
+
+    def test_04_retrieve_hs_code(self):
+        """Try to retrieve HS code on empty recordset and multi.
+
+        Case 1: empty recordset.
+        Case 2: multiple records in recordset.
+        """
+        # Case 1.
+        self.assertEqual(self.ProductProduct.retrieve_hs_code('lt'), False)
+        # Case 2.
+        with self.assertRaises(ValueError):
+            (self.product_desk | self.product_chair).retrieve_hs_code('lt')
+
+    def test_05_check_hs_code(self):
+        """Check if main HS code constraints with countries present.
+
+        Case 1: try to make code less than 6 numbers.
+        Case 2: try to make code more than 6 numbers.
+        Case 3: try to use non digit symbols.
+        Case 4: try to make code False.
+        """
+        # Case 1.
+        with self.assertRaises(ValidationError):
+            self.product_desk.hs_code = '123'
+        with self.assertRaises(ValidationError):
+            self.product_template_desk.hs_code = '321'
+        # Case 2.
+        with self.assertRaises(ValidationError):
+            self.product_desk.hs_code = '1234567'
+        # Case 3.
+        with self.assertRaises(ValidationError):
+            self.product_desk.hs_code = '12345X'
+        # Case 4.
+        with self.assertRaises(ValidationError):
+            self.product_desk.hs_code = False
+
+    def test_06_check_country_hs_code(self):
+        """Check if HS code per country can be only digits."""
+        with self.assertRaises(ValidationError):
+            self.hs_code_lt.code = 'X123'
+
+    def test_07_check_is_origin_country(self):
+        """Make sure only one origin is allowed per product tmpl."""
+        with self.assertRaises(ValidationError):
+            self.hs_code_lt.is_origin_country = True
+        with self.assertRaises(ValidationError):
+            self.product_template_desk.hs_code_ids = [
+                (
+                    1,
+                    self.hs_code_fr.id,
+                    {'is_origin_country': True}
+                )
+            ]
+
+    @mute_logger('odoo.sql_db')
+    def test_08_check_hs_code_country_id(self):
+        """Make sure country is unique per product template HS code."""
+        with self.assertRaises(IntegrityError):
+            self.hs_code_lt.country_id = self.country_us.id

--- a/delivery_hs_code_country/views/product_template_views.xml
+++ b/delivery_hs_code_country/views/product_template_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="product_template_hs_code_inherit" model="ir.ui.view">
+        <field name="name">product.template.form.hs.code.country</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="delivery_hs_code.product_template_hs_code"/>
+        <field name="arch" type="xml">
+            <field name="hs_code" position="after">
+                    <field
+                        colspan="2"
+                        nolabel="1"
+                        name="hs_code_ids"
+                        attrs="{'invisible': [('hs_code', '=', False)]}"
+                    >
+                        <tree editable="bottom">
+                            <field name="product_tmpl_id" invisible="1"/>
+                            <field name="name"/>
+                            <field name="code"/>
+                            <field name="country_id"/>
+                            <field name="is_origin_country"/>
+                        </tree>
+                    </field>
+                    <field
+                        name="country_origin_id"
+                        attrs="{'invisible': [('country_origin_id', '=', False)]}"
+                    />
+            </field>
+            <field name="hs_code" position="attributes">
+                <attribute name="attrs">{'required': [('hs_code_ids', '!=', [])]}</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Product Harmonized System Codes first six number must be the same, but
remaining numbers can be different per country.

This module allows to specify remaining part of code per country on
products. Can also mark origin country.

[BRANCH] feature/hs-code-country-ala