### PR TITLE
[IMP] delivery_hs_code_country: hs_code in slip

### DIFF
--- a/delivery_hs_code_country/__manifest__.py
+++ b/delivery_hs_code_country/__manifest__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for full copyright and licensing details.
 {
     'name': "Delivery HS Code per Country",
-    'version': '15.0.2.0.0-rc.1',
+    'version': '15.0.2.0.0',
     'summary': 'delivery, harmonized code, origin country, countries',
     'license': 'LGPL-3',
     'author': "Andrius Laukavičius",
@@ -15,6 +15,7 @@
     'data': [
         'security/ir.model.access.csv',
         'views/product_template_views.xml',
+        'reports/report_delivery_slip.xml',
     ],
     'installable': True,
 }

--- a/delivery_hs_code_country/models/__init__.py
+++ b/delivery_hs_code_country/models/__init__.py
@@ -1,2 +1,12 @@
-from . import product_template, product_product, product_template_hs_code
-__all__ = [product_template, product_product, product_template_hs_code]
+from . import (
+    product_template,
+    product_product,
+    product_template_hs_code,
+    stock_move_line,
+)
+__all__ = [
+    product_template,
+    product_product,
+    product_template_hs_code,
+    stock_move_line,
+]

--- a/delivery_hs_code_country/models/stock_move_line.py
+++ b/delivery_hs_code_country/models/stock_move_line.py
@@ -1,0 +1,24 @@
+from odoo import models
+
+
+class StockMoveLine(models.Model):
+    """Extend to use hs_code by country aggregated lines."""
+
+    _inherit = 'stock.move.line'
+
+    def _get_aggregated_product_quantities(self, **kwargs):
+        aggregated_move_lines = super()._get_aggregated_product_quantities(
+            **kwargs
+        )
+        moves = self.mapped('move_id')
+        for aggregated_move_line in aggregated_move_lines:
+            product = aggregated_move_lines[aggregated_move_line]['product']
+            # Assuming unique products match number of moves.
+            move = moves.filtered(lambda r: r.product_id == product)
+            if move:
+                country_code = move.picking_id.partner_id.country_id.code
+                hs_code = product.retrieve_hs_code(country_code=country_code)
+                aggregated_move_lines[aggregated_move_line][
+                    'hs_code'
+                ] = hs_code
+        return aggregated_move_lines

--- a/delivery_hs_code_country/reports/report_delivery_slip.xml
+++ b/delivery_hs_code_country/reports/report_delivery_slip.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template
+        id="stock_report_delivery_has_serial_move_line_inherit_delivery"
+        inherit_id="delivery.stock_report_delivery_has_serial_move_line_inherit_delivery"
+    >
+        <xpath expr="//span[@t-field='move_line.product_id.hs_code']" position="attributes">
+            <attribute name="t-field"/>
+            <attribute name="t-esc">move_line.product_id(move_line.picking_id.partner_id.country_id.code)</attribute>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
hs_code is used in delivery slip, so we are replacing original one,
which does not cover HS Codes by country.

[BRANCH] imp/hs-code