### PR TITLE
[FIX] product_stamp_configurator: _calc_weight

### DIFF
--- a/product_stamp_configurator/__manifest__.py
+++ b/product_stamp_configurator/__manifest__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for full copyright and licensing details.
 {
     'name': "Product Stamp Configurator",
-    'version': '16.0.1.2.0',
+    'version': '16.0.1.2.1',
     'summary': 'Base stamp product configurator module',
     'license': 'LGPL-3',
     'author': "Andrius Laukavičius",

--- a/product_stamp_configurator/migrations/16.0.1.2.1/pre-migration.py
+++ b/product_stamp_configurator/migrations/16.0.1.2.1/pre-migration.py
@@ -1,0 +1,9 @@
+from odoo.tools import column_exists, rename_column
+
+
+def migrate(cr, version):
+    table = 'stamp_material'
+    old_name = 'weight_coefficient'
+    new_name = 'weight'
+    if column_exists(cr, table, old_name):
+        rename_column(cr, table, old_name, new_name)

--- a/product_stamp_configurator/models/product_category.py
+++ b/product_stamp_configurator/models/product_category.py
@@ -24,6 +24,7 @@ class ProductCategory(models.Model):
         STAMP_TYPES,
         compute='_compute_nearest_stamp_type',
         store=True,
+        recursive=True,
     )
 
     @api.depends(

--- a/product_stamp_configurator/models/stamp_design.py
+++ b/product_stamp_configurator/models/stamp_design.py
@@ -21,7 +21,7 @@ class StampDesign(models.Model):
     )
     is_embossed = fields.Boolean()
     engraving_speed = fields.Integer(help="Engraving speed (min/100 sqcm)")
-    weight_coefficient = fields.Float(string="Weight kg/cm²", digits=DP_WEIGHT)
+    weight_coefficient = fields.Float(digits=DP_WEIGHT)
     company_id = fields.Many2one(
         'res.company', required=True, default=lambda s: s.env.company
     )

--- a/product_stamp_configurator/models/stamp_material.py
+++ b/product_stamp_configurator/models/stamp_material.py
@@ -14,7 +14,7 @@ class StampMaterial(models.Model):
     thickness = fields.Float("Thickness, mm")
     product_id = fields.Many2one('product.product', "Raw Material")
     price = fields.Float("Price per Square Centimeter", digits=DP_PRICE)
-    weight_coefficient = fields.Float(string="Weight kg/cm²", digits=DP_WEIGHT)
+    weight = fields.Float(string="Weight kg/cm²", digits=DP_WEIGHT)
     company_id = fields.Many2one(
         'res.company', required=True, default=lambda s: s.env.company
     )

--- a/product_stamp_configurator/tests/common.py
+++ b/product_stamp_configurator/tests/common.py
@@ -30,7 +30,7 @@ class TestProductStampConfiguratorCommon(TransactionCase):
                 'code': 'F',
                 'category_id': cls.product_categ_consu.id,
                 'engraving_speed': 25,
-                'weight_coefficient': 1.4,
+                'weight_coefficient': 1.5,
                 'company_id': cls.company_main.id,
             }
         )
@@ -75,7 +75,7 @@ class TestProductStampConfiguratorCommon(TransactionCase):
                 'thickness': 7,
                 'product_id': cls.product_bin.id,
                 'price': 0.09,
-                'weight_coefficient': 1.4,
+                'weight': 1.4,
                 'company_id': cls.company_main.id,
             }
         )
@@ -87,7 +87,7 @@ class TestProductStampConfiguratorCommon(TransactionCase):
                 'thickness': 0.5,
                 'product_id': cls.product_drawer.id,
                 'price': 0.02,
-                'weight_coefficient': 0.6,
+                'weight': 0.6,
                 'company_id': cls.company_main.id,
             }
         )

--- a/product_stamp_configurator/tests/test_stamp_configure.py
+++ b/product_stamp_configurator/tests/test_stamp_configure.py
@@ -39,7 +39,7 @@ class TestStampConfigure(TestProductStampConfiguratorCommon):
         self.assertEqual(product_die.company_id, self.company_main)
         self.assertEqual(product_die.stamp_type, 'die')
         self.assertFalse(product_die.is_insert_die)
-        self.assertEqual(product_die.weight, 294.0)
+        self.assertEqual(product_die.weight, 315.0)
         self.assertEqual(product_die.type, 'consu')
         self.assertEqual(product_die.default_code, '1111F1B7 / 2222')
         self.assertEqual(product_die.name, 'Brass Die, HFS, F1, 7 mm+ Spare 3 pcs')
@@ -54,7 +54,7 @@ class TestStampConfigure(TestProductStampConfiguratorCommon):
         self.assertEqual(product_counter_die.company_id, self.company_main)
         self.assertEqual(product_counter_die.stamp_type, 'counter_die')
         self.assertFalse(product_counter_die.is_insert_die)
-        self.assertEqual(product_counter_die.weight, 126.0)
+        self.assertEqual(product_counter_die.weight, 135.0)
         self.assertEqual(product_counter_die.type, 'consu')
         self.assertEqual(product_counter_die.default_code, '1111F1P1P0.5 / 2222')
         self.assertEqual(
@@ -69,7 +69,7 @@ class TestStampConfigure(TestProductStampConfiguratorCommon):
         self.assertEqual(product_mold.company_id, self.company_main)
         self.assertEqual(product_mold.stamp_type, 'mold')
         self.assertFalse(product_mold.is_insert_die)
-        self.assertEqual(product_die.weight, 294)
+        self.assertEqual(product_die.weight, 315.0)
         self.assertEqual(product_mold.type, 'service')
         self.assertEqual(product_mold.default_code, '1111F1P1 / 2222')
         self.assertEqual(product_mold.name, 'Molding service F1')
@@ -139,7 +139,7 @@ class TestStampConfigure(TestProductStampConfiguratorCommon):
         product_die = res['die']['product']
         self.assertEqual(product_die.stamp_type, 'die')
         self.assertTrue(product_die.is_insert_die)
-        self.assertEqual(product_die.weight, 294.0)
+        self.assertEqual(product_die.weight, 315.0)
         self.assertEqual(product_die.type, 'consu')
         self.assertEqual(product_die.default_code, '1111F1iF2B7 / 2222')
         self.assertEqual(

--- a/product_stamp_configurator/views/stamp_material.xml
+++ b/product_stamp_configurator/views/stamp_material.xml
@@ -16,7 +16,7 @@
                     widget="monetary"
                     options="{'currency_field': 'currency_id', 'field_digits': True}"
                 />
-                <field name="weight_coefficient"/>
+                <field name="weight"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
         </field>
@@ -43,7 +43,7 @@
                             />
                             <field name="thickness"/>
                             <field name="product_id"/>
-                            <field name="weight_coefficient"/>
+                            <field name="weight"/>
                             <field name="company_id" groups="base.group_multi_company"/>
                         </group>
                     </group>

--- a/product_stamp_configurator/wizards/stamp_configure.py
+++ b/product_stamp_configurator/wizards/stamp_configure.py
@@ -254,9 +254,7 @@ class StampConfigure(models.TransientModel):
 
     def _calc_weight(self, material):
         self.ensure_one()
-        return (
-            self.area * self.design_id.weight_coefficient * material.weight_coefficient
-        )
+        return self.area * self.design_id.weight_coefficient * material.weight
 
     def _create_die(self, price_digits):
         self.ensure_one()
@@ -291,7 +289,7 @@ class StampConfigure(models.TransientModel):
             {
                 **self._prepare_common_product_vals(),
                 'is_insert_die': self.is_insert_die,
-                'weight': self._calc_weight(self.design_id),
+                'weight': self._calc_weight(self.material_id),
                 'categ_id': self.design_id.category_id.id,
                 # TODO: for now we have fixed type, but might be good to
                 # be able to specify one via design?
@@ -327,7 +325,7 @@ class StampConfigure(models.TransientModel):
         return self.env['product.product'].create(
             {
                 **self._prepare_common_product_vals(),
-                'weight': self._calc_weight(self.design_id),
+                'weight': self._calc_weight(self.material_id),
                 'categ_id': self.category_mold_id.id,
                 'detailed_type': 'service',
                 'default_code': code.generate_mold_code(self),


### PR DESCRIPTION
design object was being passed instead of expected material object, thus weight was calculated incorrectly for both die and mold products.

We also now renamed `weight_coefficient` field to `weight` on `material.stamp`, because it is weight of kg/cm², not a coefficient.

Also adding `recursive=True` on nearest_stamp_type field, because we are doing recursive computation (to avoid warnings).