### PR TITLE
[IMP] product_stamp_configurator: separate unit dp

### DIFF
--- a/product_stamp_configurator/const.py
+++ b/product_stamp_configurator/const.py
@@ -1,3 +1,4 @@
 DEFAULT_PRICE_DIGITS = 2
 DP_WEIGHT = 'Stamp Weight'
 DP_PRICE = 'Product Price'
+DP_UNIT_PRICE = 'Stamp Product Price'

--- a/product_stamp_configurator/data/decimal_precision.xml
+++ b/product_stamp_configurator/data/decimal_precision.xml
@@ -8,4 +8,12 @@
         <field name="name">Stamp Weight</field>
         <field name="digits">6</field>
     </record>
+    <record
+        id="decimal_precision_stamp_unit_price"
+        forcecreate="True"
+        model="decimal.precision"
+    >
+        <field name="name">Stamp Unit Price</field>
+        <field name="digits">2</field>
+    </record>
 </odoo>

--- a/product_stamp_configurator/wizards/stamp_configure.py
+++ b/product_stamp_configurator/wizards/stamp_configure.py
@@ -3,7 +3,7 @@ import json
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
-from ..const import DP_PRICE
+from ..const import DP_PRICE, DP_UNIT_PRICE
 from ..stamp import code, description, name, parsing, price
 from ..utils import FieldTranslation, translate_field
 
@@ -160,17 +160,17 @@ class StampConfigure(models.TransientModel):
     price_sqcm_mold_custom = fields.Float("Custom Mold ㎠ Price", digits=DP_PRICE)
     price_unit_die = fields.Float(
         "Die Unit Price",
-        digits=DP_PRICE,
+        digits=DP_UNIT_PRICE,
         compute='_compute_prices',
     )
     price_unit_counter_die = fields.Float(
         "Counter-Die Unit Price",
-        digits=DP_PRICE,
+        digits=DP_UNIT_PRICE,
         compute='_compute_prices',
     )
     price_unit_mold = fields.Float(
         "Mold Unit Price",
-        digits=DP_PRICE,
+        digits=DP_UNIT_PRICE,
         compute='_compute_prices',
     )
     cost_unit_die = fields.Float(


### PR DESCRIPTION
When we use final unit price creating product, we want it to be different than standard Product Price one, to make it more flexible.