### PR TITLE
[ADD] package_configurator: setup_qty_mode

### DIFF
--- a/package_configurator/const.py
+++ b/package_configurator/const.py
@@ -12,6 +12,7 @@ class DecimalPrecision(StrEnum):
 
 
 class SetupType(StrEnum):
+    # TODO: rename SHEET to PRODUCTION.
     SHEET = 'sheet'
     PRINT = 'print'
 

--- a/package_configurator/const.py
+++ b/package_configurator/const.py
@@ -12,8 +12,7 @@ class DecimalPrecision(StrEnum):
 
 
 class SetupType(StrEnum):
-    # TODO: rename SHEET to PRODUCTION.
-    SHEET = 'sheet'
+    PRODUCTION = 'production'
     PRINT = 'print'
 
 
@@ -23,7 +22,7 @@ class SheetTypeScope(StrEnum):
 
 
 SETUP_TYPE_SELECTION = [
-    (SetupType.SHEET, "Sheet"),
+    (SetupType.PRODUCTION, "Production"),
     (SetupType.PRINT, "Print"),
 ]
 

--- a/package_configurator/models/package_box_setup.py
+++ b/package_configurator/models/package_box_setup.py
@@ -24,6 +24,14 @@ class PackageBoxSetup(models.Model):
         const.SETUP_TYPE_SELECTION,
         required=True,
     )
+    setup_qty_mode = fields.Selection(
+        [('fixed', "Fixed"), ('relative', "Relative")],
+        string="Setup Quantity Mode",
+        required=True,
+        default='fixed',
+        help="* Fixed: use defined setup quantity on rule\n* Relative: calculate"
+        " proportional quantity from the matched rule to the next role.",
+    )
     active = fields.Boolean(default=True)
     rule_ids = fields.One2many('package.box.setup.rule', 'setup_id', string="Rules")
     sequence = fields.Integer(default=10)

--- a/package_configurator/models/package_box_setup.py
+++ b/package_configurator/models/package_box_setup.py
@@ -54,14 +54,18 @@ class PackageBoxSetup(models.Model):
     max_layout_width = fields.Float("Maximum Layout Width (mm)", help=HELP_NO_LIMIT)
 
     def match_setup_rule(
-        self, box_qty: int, layout: Layout2D | None = None, box_type=None
+        self,
+        quantity: int,
+        component_type: str | None = None,
+        layout: Layout2D | None = None,
+        box_type=None,
     ):
         """Match setup rule by scanning setups and their rules."""
         for setup in self:
             if not setup._match_setup(layout=layout, box_type=box_type):
                 continue
             for rule in setup._rules_ordered:
-                if rule.match_rule(box_qty):
+                if rule.match_rule(quantity, component_type=component_type):
                     return rule
         return self.env['package.box.setup.rule']
 

--- a/package_configurator/models/package_box_setup.py
+++ b/package_configurator/models/package_box_setup.py
@@ -32,6 +32,13 @@ class PackageBoxSetup(models.Model):
         help="* Fixed: use defined setup quantity on rule\n* Relative: calculate"
         " proportional quantity from the matched rule to the next role.",
     )
+    setup_qty_measure = fields.Selection(
+        [('cut', "Cut Sheets"), ('raw', "Raw Sheets")],
+        required=True,
+        string="Setup Quantity Measure",
+        default='cut',
+        help="How to measure setup quantity",
+    )
     active = fields.Boolean(default=True)
     rule_ids = fields.One2many('package.box.setup.rule', 'setup_id', string="Rules")
     sequence = fields.Integer(default=10)

--- a/package_configurator/models/package_box_setup.py
+++ b/package_configurator/models/package_box_setup.py
@@ -1,6 +1,7 @@
 from odoo import fields, models
 
 from .. import const
+from ..utils.fitter import calc_sheet_quantity
 from ..value_objects.layout import Layout2D
 
 HELP_NO_LIMIT = "0 means no limit"
@@ -33,11 +34,21 @@ class PackageBoxSetup(models.Model):
         " proportional quantity from the matched rule to the next role.",
     )
     setup_qty_measure = fields.Selection(
-        [('cut', "Cut Sheets"), ('raw', "Raw Sheets")],
+        [('cut_sheet', "Cut Sheet"), ('raw_sheet', "Raw Sheet")],
         required=True,
         string="Setup Quantity Measure",
-        default='cut',
-        help="How to measure setup quantity",
+        default='cut_sheet',
+        help="How to measure Setup Quantity on rules",
+    )
+    inp_qty_measure = fields.Selection(
+        # Box here means unconverted quantity coming from circulation which is boxes,
+        # but in reality it would be quantity of specific component of a box!
+        [('box', "Box"), ('raw_sheet', "Raw Sheet")],
+        required=True,
+        string="Input Quantity Measure",
+        default='box',
+        help="How to measure Input Quantity on rules. "
+        + "Minimum Quantity must match the measure!",
     )
     active = fields.Boolean(default=True)
     rule_ids = fields.One2many('package.box.setup.rule', 'setup_id', string="Rules")
@@ -60,19 +71,40 @@ class PackageBoxSetup(models.Model):
     max_layout_length = fields.Float("Maximum Layout Length (mm)", help=HELP_NO_LIMIT)
     max_layout_width = fields.Float("Maximum Layout Width (mm)", help=HELP_NO_LIMIT)
 
+    def convert_inp_qty(self, qty: int, fit_qty: int):
+        """Calc real input qty when quantity of boxes/components is known."""
+        self.ensure_one()
+        if self.inp_qty_measure == 'box':
+            return qty
+        try:
+            return calc_sheet_quantity(qty, fit_qty)
+        except ZeroDivisionError:
+            return 0
+
     def match_setup_rule(
         self,
         quantity: int,
+        fit_qty: int,
         component_type: str | None = None,
         layout: Layout2D | None = None,
         box_type=None,
     ):
-        """Match setup rule by scanning setups and their rules."""
+        """Match setup rule by scanning setups and their rules.
+
+        Args:
+            quantity: quantity of boxes or components
+            fit_qty: number of specific component that fits on raw sheet.
+            component_type: which component to match in setup rules if any.
+            layout: layout to match in setup if any.
+            box_type: whether box_type must match on setup.
+
+        """
         for setup in self:
             if not setup._match_setup(layout=layout, box_type=box_type):
                 continue
+            inp_qty = setup.convert_inp_qty(quantity, fit_qty)
             for rule in setup._rules_ordered:
-                if rule.match_rule(quantity, component_type=component_type):
+                if rule.match_rule(inp_qty, component_type=component_type):
                     return rule
         return self.env['package.box.setup.rule']
 

--- a/package_configurator/models/package_box_setup_rule.py
+++ b/package_configurator/models/package_box_setup_rule.py
@@ -1,3 +1,5 @@
+import math
+
 from odoo import api, fields, models
 
 
@@ -12,6 +14,7 @@ class PackageBoxSetupRule(models.Model):
     min_qty = fields.Integer(
         "Minimum Box Quantity", help="Minimum quantity of boxes to match this rule"
     )
+    # TODO: rename to setup_fixed_qty
     setup_qty = fields.Integer(
         "Setup Quantity",
         # NOTE. This is quantity for prepared material, like cut sheet, not the whole
@@ -19,6 +22,21 @@ class PackageBoxSetupRule(models.Model):
         help="Material wastage quantity used when doing setup",
         required=True,
     )
+
+    @property
+    def _greater_rule(self):
+        self.ensure_one()
+        current_rule = self
+        rules = self.setup_id._rules_ordered
+        # We start from second rule, because first one won't have any
+        # previous one.
+        for idx, rule in enumerate(rules[1:], start=1):
+            if rule == current_rule:
+                try:
+                    return rules[idx - 1]
+                except IndexError:
+                    return self.browse()
+        return self.browse()
 
     @api.depends('setup_id', 'min_qty', 'setup_qty')
     def _compute_name(self):
@@ -37,3 +55,22 @@ class PackageBoxSetupRule(models.Model):
     def match_rule(self, box_qty: int):
         self.ensure_one()
         return box_qty >= self.min_qty
+
+    def calc_setup_qty(self, min_qty: int) -> int:
+        self.ensure_one()
+        if self.setup_id.setup_qty_mode == 'fixed':
+            return self.setup_qty
+        return self._calc_relative_setup_qty(min_qty)
+
+    def _calc_relative_setup_qty(self, qty: int) -> int:
+        self.ensure_one()
+        # Greater rule must have higher quantity than current
+        greater_rule = self._greater_rule
+        if not greater_rule or qty <= self.min_qty:
+            return self.setup_qty
+        if greater_rule.min_qty <= max(qty, self.min_qty):
+            return greater_rule.setup_qty
+        rel_min_qty = greater_rule.min_qty - self.min_qty
+        rel_setup_qty = greater_rule.setup_qty - self.setup_qty
+        ratio = rel_setup_qty / rel_min_qty
+        return math.ceil((qty - self.min_qty) * ratio + self.setup_qty)

--- a/package_configurator/models/package_box_setup_rule.py
+++ b/package_configurator/models/package_box_setup_rule.py
@@ -11,7 +11,8 @@ class PackageBoxSetupRule(models.Model):
     name = fields.Char(compute='_compute_name')
     setup_id = fields.Many2one('package.box.setup', required=True, ondelete='cascade')
     min_qty = fields.Integer(
-        "Minimum Box Quantity", help="Minimum quantity of boxes to match this rule"
+        "Minimum Quantity",
+        help="Minimum quantity of either boxes or raw sheets to match this rule",
     )
     component_type = fields.Selection(
         lambda s: s.env[
@@ -24,8 +25,6 @@ class PackageBoxSetupRule(models.Model):
     )
     setup_fixed_qty = fields.Integer(
         "Fixed Setup Quantity",
-        # NOTE. This is quantity for prepared material, like cut sheet, not the whole
-        # raw sheet!
         help="Material wastage quantity used when doing setup",
         required=True,
     )
@@ -57,19 +56,20 @@ class PackageBoxSetupRule(models.Model):
             # To order rules with component_type before without component_type.
             rec.component_type_sequence = 1 if rec.component_type else 2
 
-    def match_rule(self, qty: int, component_type: str | None = None):
+    def match_rule(self, inp_qty: int, component_type: str | None = None):
         self.ensure_one()
-        return qty >= self.min_qty and (
+        return inp_qty >= self.min_qty and (
             not self.component_type
             or component_type is None
             or self.component_type == component_type
         )
 
-    def calc_setup_qty(self, qty: int) -> int:
+    def calc_setup_qty(self, inp_qty: int) -> int:
+        """Calc real setup quantity when quantity of boxes/components is known."""
         self.ensure_one()
         if self.setup_id.setup_qty_mode == 'fixed':
             return self.setup_fixed_qty
-        return self._calc_relative_setup_qty(qty)
+        return self._calc_relative_setup_qty(inp_qty)
 
     def _calc_relative_setup_qty(self, qty: int) -> int:
         self.ensure_one()

--- a/package_configurator/models/package_box_setup_rule.py
+++ b/package_configurator/models/package_box_setup_rule.py
@@ -15,8 +15,8 @@ class PackageBoxSetupRule(models.Model):
         "Minimum Box Quantity", help="Minimum quantity of boxes to match this rule"
     )
     # TODO: rename to setup_fixed_qty
-    setup_qty = fields.Integer(
-        "Setup Quantity",
+    setup_fixed_qty = fields.Integer(
+        "Fixed Setup Quantity",
         # NOTE. This is quantity for prepared material, like cut sheet, not the whole
         # raw sheet!
         help="Material wastage quantity used when doing setup",
@@ -38,11 +38,11 @@ class PackageBoxSetupRule(models.Model):
                     return self.browse()
         return self.browse()
 
-    @api.depends('setup_id', 'min_qty', 'setup_qty')
+    @api.depends('setup_id', 'min_qty', 'setup_fixed_qty')
     def _compute_name(self):
         for rec in self:
             setup = rec.setup_id
-            rec.name = f'{setup.name} ({rec.min_qty}/{rec.setup_qty})'
+            rec.name = f'{setup.name} ({rec.min_qty}/{rec.setup_fixed_qty})'
 
     _sql_constraints = [
         (
@@ -59,7 +59,7 @@ class PackageBoxSetupRule(models.Model):
     def calc_setup_qty(self, min_qty: int) -> int:
         self.ensure_one()
         if self.setup_id.setup_qty_mode == 'fixed':
-            return self.setup_qty
+            return self.setup_fixed_qty
         return self._calc_relative_setup_qty(min_qty)
 
     def _calc_relative_setup_qty(self, qty: int) -> int:
@@ -67,10 +67,10 @@ class PackageBoxSetupRule(models.Model):
         # Greater rule must have higher quantity than current
         greater_rule = self._greater_rule
         if not greater_rule or qty <= self.min_qty:
-            return self.setup_qty
+            return self.setup_fixed_qty
         if greater_rule.min_qty <= max(qty, self.min_qty):
-            return greater_rule.setup_qty
+            return greater_rule.setup_fixed_qty
         rel_min_qty = greater_rule.min_qty - self.min_qty
-        rel_setup_qty = greater_rule.setup_qty - self.setup_qty
+        rel_setup_qty = greater_rule.setup_fixed_qty - self.setup_fixed_qty
         ratio = rel_setup_qty / rel_min_qty
-        return math.ceil((qty - self.min_qty) * ratio + self.setup_qty)
+        return math.ceil((qty - self.min_qty) * ratio + self.setup_fixed_qty)

--- a/package_configurator/models/package_box_setup_rule.py
+++ b/package_configurator/models/package_box_setup_rule.py
@@ -6,15 +6,22 @@ from odoo import api, fields, models
 class PackageBoxSetupRule(models.Model):
     _name = 'package.box.setup.rule'
     _description = "Package Box Setup Rule"
-    _order = "min_qty desc, id"
+    _order = "component_type_sequence, min_qty desc, id"
 
     name = fields.Char(compute='_compute_name')
-
     setup_id = fields.Many2one('package.box.setup', required=True, ondelete='cascade')
     min_qty = fields.Integer(
         "Minimum Box Quantity", help="Minimum quantity of boxes to match this rule"
     )
-    # TODO: rename to setup_fixed_qty
+    component_type = fields.Selection(
+        lambda s: s.env[
+            'package.configurator.box.component'
+        ]._get_component_type_selection(),
+    )
+    component_type_sequence = fields.Integer(
+        compute='_compute_component_type_sequence',
+        store=True,
+    )
     setup_fixed_qty = fields.Integer(
         "Fixed Setup Quantity",
         # NOTE. This is quantity for prepared material, like cut sheet, not the whole
@@ -44,17 +51,19 @@ class PackageBoxSetupRule(models.Model):
             setup = rec.setup_id
             rec.name = f'{setup.name} ({rec.min_qty}/{rec.setup_fixed_qty})'
 
-    _sql_constraints = [
-        (
-            'min_qty_setup_uniq',
-            'unique (min_qty, setup_id)',
-            'The Minimum Quantity must be Unique per Setup!',
-        )
-    ]
+    @api.depends('component_type')
+    def _compute_component_type_sequence(self):
+        for rec in self:
+            # To order rules with component_type before without component_type.
+            rec.component_type_sequence = 1 if rec.component_type else 2
 
-    def match_rule(self, box_qty: int):
+    def match_rule(self, qty: int, component_type: str | None = None):
         self.ensure_one()
-        return box_qty >= self.min_qty
+        return qty >= self.min_qty and (
+            not self.component_type
+            or component_type is None
+            or self.component_type == component_type
+        )
 
     def calc_setup_qty(self, min_qty: int) -> int:
         self.ensure_one()

--- a/package_configurator/models/package_box_setup_rule.py
+++ b/package_configurator/models/package_box_setup_rule.py
@@ -65,11 +65,11 @@ class PackageBoxSetupRule(models.Model):
             or self.component_type == component_type
         )
 
-    def calc_setup_qty(self, min_qty: int) -> int:
+    def calc_setup_qty(self, qty: int) -> int:
         self.ensure_one()
         if self.setup_id.setup_qty_mode == 'fixed':
             return self.setup_fixed_qty
-        return self._calc_relative_setup_qty(min_qty)
+        return self._calc_relative_setup_qty(qty)
 
     def _calc_relative_setup_qty(self, qty: int) -> int:
         self.ensure_one()

--- a/package_configurator/models/package_configurator_box.py
+++ b/package_configurator/models/package_configurator_box.py
@@ -204,7 +204,7 @@ class PackageConfiguratorBox(models.Model):
     def _prepare_box_setups_domain(self):
         self.ensure_one()
         # By default we always look for sheet type setups.
-        setup_types = [const.SetupType.SHEET]
+        setup_types = [const.SetupType.PRODUCTION]
         if self.print_house_id:
             setup_types.append(const.SetupType.PRINT)
         return [

--- a/package_configurator/models/package_configurator_box_circulation_item_setup.py
+++ b/package_configurator/models/package_configurator_box_circulation_item_setup.py
@@ -30,11 +30,14 @@ class PackageConfiguratorBoxCirculationItemSetup(models.Model):
         for rec in self:
             component = rec.circulation_item_id.component_id
             setup_raw_qty = 0
-            fit_qty = component.fit_qty
-            if fit_qty:
-                setup_raw_qty = calc_sheet_quantity(
-                    rec.setup_rule_id.setup_fixed_qty, fit_qty
-                )
+            if rec.setup_id.setup_qty_measure == 'cut':
+                fit_qty = component.fit_qty
+                if fit_qty:
+                    setup_raw_qty = calc_sheet_quantity(
+                        rec.setup_rule_id.setup_fixed_qty, fit_qty
+                    )
+            else:
+                setup_raw_qty = rec.setup_rule_id.setup_fixed_qty
             rec.setup_raw_qty = setup_raw_qty
 
     @api.model

--- a/package_configurator/models/package_configurator_box_circulation_item_setup.py
+++ b/package_configurator/models/package_configurator_box_circulation_item_setup.py
@@ -53,7 +53,10 @@ class PackageConfiguratorBoxCirculationItemSetup(models.Model):
             if not self._is_circ_item_need_setup(circ_item, setup_type, sgroup):
                 continue
             setup_rule = sgroup.match_setup_rule(
-                circ.quantity, layout=layout, box_type=circ.configurator_id.box_type_id
+                circ.quantity,
+                component_type=component.component_type,
+                layout=layout,
+                box_type=circ.configurator_id.box_type_id,
             )
             if setup_rule:
                 vals_list.append(self._prepare_ciculation_setup(circ_item, setup_rule))

--- a/package_configurator/models/package_configurator_box_circulation_item_setup.py
+++ b/package_configurator/models/package_configurator_box_circulation_item_setup.py
@@ -26,17 +26,18 @@ class PackageConfiguratorBoxCirculationItemSetup(models.Model):
     def _setup_raw_qty(self):
         self.ensure_one()
         circ_item = self.circulation_item_id
-        setup_raw_qty = self.setup_rule_id.calc_setup_qty(
-            circ_item.circulation_id.quantity
-        )
-        # With raw measure, nothing needs to be converted.
-        if self.setup_id.setup_qty_measure == 'raw':
-            return setup_raw_qty
-        # Handle `cut` measure.
         fit_qty = circ_item.component_id.fit_qty
         if not fit_qty:
             return 0
-        # setup quantity on rule is in cut sheets measure, to we convert it to
+        inp_qty = self.setup_id.convert_inp_qty(
+            circ_item.circulation_id.quantity, fit_qty
+        )
+        setup_raw_qty = self.setup_rule_id.calc_setup_qty(inp_qty)
+        # With raw measure, nothing needs to be converted.
+        if self.setup_id.setup_qty_measure == 'raw_sheet':
+            return setup_raw_qty
+        # Handle `cut` measure.
+        # setup quantity on rule is in cut sheets measure, so we convert it to
         # raw measure.
         return calc_sheet_quantity(setup_raw_qty, fit_qty)
 
@@ -66,6 +67,7 @@ class PackageConfiguratorBoxCirculationItemSetup(models.Model):
                 continue
             setup_rule = sgroup.match_setup_rule(
                 circ.quantity,
+                component.fit_qty,
                 component_type=component.component_type,
                 layout=layout,
                 box_type=circ.configurator_id.box_type_id,

--- a/package_configurator/models/package_configurator_box_circulation_item_setup.py
+++ b/package_configurator/models/package_configurator_box_circulation_item_setup.py
@@ -33,7 +33,7 @@ class PackageConfiguratorBoxCirculationItemSetup(models.Model):
             fit_qty = component.fit_qty
             if fit_qty:
                 setup_raw_qty = calc_sheet_quantity(
-                    rec.setup_rule_id.setup_qty, fit_qty
+                    rec.setup_rule_id.setup_fixed_qty, fit_qty
                 )
             rec.setup_raw_qty = setup_raw_qty
 

--- a/package_configurator/models/package_configurator_box_circulation_item_setup.py
+++ b/package_configurator/models/package_configurator_box_circulation_item_setup.py
@@ -22,23 +22,32 @@ class PackageConfiguratorBoxCirculationItemSetup(models.Model):
         "Raw Setup Quantity", compute='_compute_setup_raw_qty'
     )
 
+    @property
+    def _setup_raw_qty(self):
+        self.ensure_one()
+        circ_item = self.circulation_item_id
+        setup_raw_qty = self.setup_rule_id.calc_setup_qty(
+            circ_item.circulation_id.quantity
+        )
+        # With raw measure, nothing needs to be converted.
+        if self.setup_id.setup_qty_measure == 'raw':
+            return setup_raw_qty
+        # Handle `cut` measure.
+        fit_qty = circ_item.component_id.fit_qty
+        if not fit_qty:
+            return 0
+        # setup quantity on rule is in cut sheets measure, to we convert it to
+        # raw measure.
+        return calc_sheet_quantity(setup_raw_qty, fit_qty)
+
     @api.depends(
         'circulation_item_id.component_id.fit_qty',
+        'circulation_item_id.circulation_id.quantity',
         'setup_rule_id',
     )
     def _compute_setup_raw_qty(self):
         for rec in self:
-            component = rec.circulation_item_id.component_id
-            setup_raw_qty = 0
-            if rec.setup_id.setup_qty_measure == 'cut':
-                fit_qty = component.fit_qty
-                if fit_qty:
-                    setup_raw_qty = calc_sheet_quantity(
-                        rec.setup_rule_id.setup_fixed_qty, fit_qty
-                    )
-            else:
-                setup_raw_qty = rec.setup_rule_id.setup_fixed_qty
-            rec.setup_raw_qty = setup_raw_qty
+            rec.setup_raw_qty = rec._setup_raw_qty
 
     @api.model
     def prepare_circulation_setups(self, circ_item, setups):

--- a/package_configurator/models/package_configurator_box_component.py
+++ b/package_configurator/models/package_configurator_box_component.py
@@ -57,6 +57,7 @@ class PackageConfiguratorBoxComponent(models.Model):
     @api.depends(
         'component_type',
         'sheet_id',
+        'print_color_id',
         'configurator_id.base_length',
         'configurator_id.base_width',
         'configurator_id.lid_height',
@@ -190,7 +191,13 @@ class PackageConfiguratorBoxComponent(models.Model):
     def _get_sheet_usable_dimensions_data(self):
         self.ensure_one()
         sheet = self.sheet_id
+        # Print house limitations can only be used if component uses
+        # color. Otherwise it means, no printing will be used for this
+        # component!
         house = self.configurator_id.print_house_id
+        if not self.print_color_id:
+            # Force empty recordset.
+            house = house.browse()
         return {
             'sheet_usable_length': min(
                 # If max is not set, it means, we have no limit, so we use sheet

--- a/package_configurator/tests/__init__.py
+++ b/package_configurator/tests/__init__.py
@@ -7,6 +7,7 @@ from . import (
     test_package_configurator_box_setup,
     test_package_configurator_box_print_cost,
     test_package_box_match_setup_rule,
+    test_package_box_setup_rule_qty,
     test_utils,
     test_package_sheet_match,
     test_package_sheet_constraints,

--- a/package_configurator/tests/test_package_box_match_setup_rule.py
+++ b/package_configurator/tests/test_package_box_match_setup_rule.py
@@ -19,10 +19,10 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         rules = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 100, 'setup_qty': 0},
-                {'setup_id': setup_1.id, 'min_qty': 200, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 300, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 400, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 100, 'setup_fixed_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 200, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 300, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 400, 'setup_fixed_qty': 0},
             ]
         )
         setup_1_rule_1 = rules[0]
@@ -73,10 +73,10 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             setup_2_rule_2,
         ) = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 100, 'setup_qty': 0},
-                {'setup_id': setup_1.id, 'min_qty': 200, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 300, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 400, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 100, 'setup_fixed_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 200, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 300, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 400, 'setup_fixed_qty': 0},
             ]
         )
         layout = Layout2D(length=100, width=50)
@@ -123,8 +123,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN layout length less than 100
@@ -158,8 +158,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN layout length less than 100
@@ -193,8 +193,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN layout width less than 100
@@ -228,8 +228,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, _setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN layout width less than 100
@@ -269,8 +269,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN layout matches second setup
@@ -308,8 +308,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN layout matches second setup
@@ -340,8 +340,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN
@@ -370,8 +370,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 0},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 0},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 0},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 0},
             ]
         )
         # WHEN

--- a/package_configurator/tests/test_package_box_match_setup_rule.py
+++ b/package_configurator/tests/test_package_box_match_setup_rule.py
@@ -81,27 +81,27 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         layout = Layout2D(length=100, width=50)
         # WHEN QTY too low for any rule
-        rule = (setup_2 | setup_1).match_setup_rule(50, layout)
+        rule = (setup_2 | setup_1).match_setup_rule(50, layout=layout)
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
         # WHEN QTY less than 200
-        rule = (setup_2 | setup_1).match_setup_rule(150, layout)
+        rule = (setup_2 | setup_1).match_setup_rule(150, layout=layout)
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN QTY less than 300
-        rule = (setup_2 | setup_1).match_setup_rule(250, layout)
+        rule = (setup_2 | setup_1).match_setup_rule(250, layout=layout)
         # THEN
         self.assertEqual(rule, setup_1_rule_2)
         # WHEN QTY is 300
-        rule = (setup_2 | setup_1).match_setup_rule(300, layout)
+        rule = (setup_2 | setup_1).match_setup_rule(300, layout=layout)
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN QTY less than 400
-        rule = (setup_2 | setup_1).match_setup_rule(350, layout)
+        rule = (setup_2 | setup_1).match_setup_rule(350, layout=layout)
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN QTY greater than 400
-        rule = (setup_2 | setup_1).match_setup_rule(450, layout)
+        rule = (setup_2 | setup_1).match_setup_rule(450, layout=layout)
         # THEN
         self.assertEqual(rule, setup_2_rule_2)
 
@@ -128,15 +128,21 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN layout length less than 100
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=50)
+        )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
         # WHEN layout length less than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=150, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=150, width=50)
+        )
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN layout length greater than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=250, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=250, width=50)
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
 
@@ -163,15 +169,21 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN layout length less than 100
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=50)
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout length less than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=150, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=150, width=50)
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout length greater than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=250, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=250, width=50)
+        )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
 
@@ -198,15 +210,21 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN layout width less than 100
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=50)
+        )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
         # WHEN layout width less than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=150))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=150)
+        )
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN layout width greater than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=250))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=250)
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
 
@@ -233,15 +251,21 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN layout width less than 100
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=50)
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout width less than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=150))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=150)
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout width greater than 200
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=50, width=250))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=50, width=250)
+        )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
 
@@ -274,12 +298,14 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN layout matches second setup
-        rule = (setup_1 | setup_2).match_setup_rule(100, Layout2D(length=160, width=50))
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, layout=Layout2D(length=160, width=50)
+        )
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN layout matches first setup
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, Layout2D(length=230, width=110)
+            100, layout=Layout2D(length=230, width=110)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
@@ -314,7 +340,7 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         # WHEN layout matches second setup
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, Layout2D(length=5000, width=5000)
+            100, layout=Layout2D(length=5000, width=5000)
         )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
@@ -378,3 +404,92 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         rule = (setup_1 | setup_2).match_setup_rule(100, box_type=box_type_2)
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
+
+    def test_11_match_setup_rule_by_component_type_all_used(self):
+        # GIVEN
+        setup_1, setup_2 = self.PackageBoxSetup.create(
+            [
+                {
+                    'name': 'MY-BOX-SHEET-SETUP-1',
+                    'setup_type': 'sheet',
+                },
+                {
+                    'name': 'MY-BOX-SHEET-SETUP-2',
+                    'setup_type': 'sheet',
+                },
+            ],
+        )
+        (
+            setup_1_rule_1,
+            setup_1_rule_2,
+            setup_2_rule_1,
+        ) = self.PackageBoxSetupRule.create(
+            [
+                {
+                    'setup_id': setup_1.id,
+                    'min_qty': 3,
+                    'setup_fixed_qty': 0,
+                    'component_type': 'base_greyboard',
+                },
+                {
+                    'setup_id': setup_1.id,
+                    'min_qty': 2,
+                    'setup_fixed_qty': 0,
+                    'component_type': 'lid_greyboard',
+                },
+                {
+                    'setup_id': setup_2.id,
+                    'min_qty': 1,
+                    'setup_fixed_qty': 0,
+                    'component_type': 'base_wrappingpaper_inside',
+                },
+            ]
+        )
+        # WHEN
+        rule = (setup_1 | setup_2).match_setup_rule(100, component_type='lid_greyboard')
+        # THEN
+        self.assertEqual(rule, setup_1_rule_2)
+
+    def test_12_match_setup_rule_by_component_type_some_used(self):
+        # GIVEN
+        setup_1, setup_2 = self.PackageBoxSetup.create(
+            [
+                {
+                    'name': 'MY-BOX-SHEET-SETUP-1',
+                    'setup_type': 'sheet',
+                },
+                {
+                    'name': 'MY-BOX-SHEET-SETUP-2',
+                    'setup_type': 'sheet',
+                },
+            ],
+        )
+        (
+            setup_1_rule_1,
+            setup_1_rule_2,
+            setup_2_rule_1,
+        ) = self.PackageBoxSetupRule.create(
+            [
+                {
+                    'setup_id': setup_1.id,
+                    'min_qty': 3,
+                    'setup_fixed_qty': 0,
+                },
+                {
+                    'setup_id': setup_1.id,
+                    'min_qty': 2,
+                    'setup_fixed_qty': 0,
+                    'component_type': 'lid_greyboard',
+                },
+                {
+                    'setup_id': setup_2.id,
+                    'min_qty': 1,
+                    'setup_fixed_qty': 0,
+                    'component_type': 'base_wrappingpaper_inside',
+                },
+            ]
+        )
+        # WHEN
+        rule = (setup_1 | setup_2).match_setup_rule(100, component_type='lid_greyboard')
+        # THEN
+        self.assertEqual(rule, setup_1_rule_2)

--- a/package_configurator/tests/test_package_box_match_setup_rule.py
+++ b/package_configurator/tests/test_package_box_match_setup_rule.py
@@ -28,27 +28,27 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1_rule_1 = rules[0]
         setup_1_rule_2 = rules[1]
         # WHEN QTY too low for any rule
-        rule = (setup_1 | setup_2).match_setup_rule(50)
+        rule = (setup_1 | setup_2).match_setup_rule(50, 1)
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
         # WHEN QTY less than 200
-        rule = (setup_1 | setup_2).match_setup_rule(150)
+        rule = (setup_1 | setup_2).match_setup_rule(150, 1)
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN QTY less than 300
-        rule = (setup_1 | setup_2).match_setup_rule(250)
+        rule = (setup_1 | setup_2).match_setup_rule(250, 1)
         # THEN
         self.assertEqual(rule, setup_1_rule_2)
         # WHEN QTY is 300
-        rule = (setup_1 | setup_2).match_setup_rule(300)
+        rule = (setup_1 | setup_2).match_setup_rule(300, 1)
         # THEN
         self.assertEqual(rule, setup_1_rule_2)
         # WHEN QTY less than 400
-        rule = (setup_1 | setup_2).match_setup_rule(350)
+        rule = (setup_1 | setup_2).match_setup_rule(350, 1)
         # THEN
         self.assertEqual(rule, setup_1_rule_2)
         # WHEN QTY greater than 400
-        rule = (setup_1 | setup_2).match_setup_rule(450)
+        rule = (setup_1 | setup_2).match_setup_rule(450, 1)
         # THEN
         self.assertEqual(rule, setup_1_rule_2)
 
@@ -81,27 +81,27 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         layout = Layout2D(length=100, width=50)
         # WHEN QTY too low for any rule
-        rule = (setup_2 | setup_1).match_setup_rule(50, layout=layout)
+        rule = (setup_2 | setup_1).match_setup_rule(50, 1, layout=layout)
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
         # WHEN QTY less than 200
-        rule = (setup_2 | setup_1).match_setup_rule(150, layout=layout)
+        rule = (setup_2 | setup_1).match_setup_rule(150, 1, layout=layout)
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN QTY less than 300
-        rule = (setup_2 | setup_1).match_setup_rule(250, layout=layout)
+        rule = (setup_2 | setup_1).match_setup_rule(250, 1, layout=layout)
         # THEN
         self.assertEqual(rule, setup_1_rule_2)
         # WHEN QTY is 300
-        rule = (setup_2 | setup_1).match_setup_rule(300, layout=layout)
+        rule = (setup_2 | setup_1).match_setup_rule(300, 1, layout=layout)
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN QTY less than 400
-        rule = (setup_2 | setup_1).match_setup_rule(350, layout=layout)
+        rule = (setup_2 | setup_1).match_setup_rule(350, 1, layout=layout)
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN QTY greater than 400
-        rule = (setup_2 | setup_1).match_setup_rule(450, layout=layout)
+        rule = (setup_2 | setup_1).match_setup_rule(450, 1, layout=layout)
         # THEN
         self.assertEqual(rule, setup_2_rule_2)
 
@@ -129,19 +129,19 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         # WHEN layout length less than 100
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=50)
+            100, 1, layout=Layout2D(length=50, width=50)
         )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
         # WHEN layout length less than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=150, width=50)
+            100, 1, layout=Layout2D(length=150, width=50)
         )
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN layout length greater than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=250, width=50)
+            100, 1, layout=Layout2D(length=250, width=50)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
@@ -170,19 +170,19 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         # WHEN layout length less than 100
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=50)
+            100, 1, layout=Layout2D(length=50, width=50)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout length less than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=150, width=50)
+            100, 1, layout=Layout2D(length=150, width=50)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout length greater than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=250, width=50)
+            100, 1, layout=Layout2D(length=250, width=50)
         )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
@@ -211,19 +211,19 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         # WHEN layout width less than 100
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=50)
+            100, 1, layout=Layout2D(length=50, width=50)
         )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
         # WHEN layout width less than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=150)
+            100, 1, layout=Layout2D(length=50, width=150)
         )
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN layout width greater than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=250)
+            100, 1, layout=Layout2D(length=50, width=250)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
@@ -252,19 +252,19 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         # WHEN layout width less than 100
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=50)
+            100, 1, layout=Layout2D(length=50, width=50)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout width less than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=150)
+            100, 1, layout=Layout2D(length=50, width=150)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
         # WHEN layout width greater than 200
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=50, width=250)
+            100, 1, layout=Layout2D(length=50, width=250)
         )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
@@ -299,13 +299,13 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         # WHEN layout matches second setup
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=160, width=50)
+            100, 1, layout=Layout2D(length=160, width=50)
         )
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
         # WHEN layout matches first setup
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=230, width=110)
+            100, 1, layout=Layout2D(length=230, width=110)
         )
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
@@ -340,7 +340,7 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         )
         # WHEN layout matches second setup
         rule = (setup_1 | setup_2).match_setup_rule(
-            100, layout=Layout2D(length=5000, width=5000)
+            100, 1, layout=Layout2D(length=5000, width=5000)
         )
         # THEN
         self.assertEqual(rule, self.PackageBoxSetupRule)
@@ -371,7 +371,7 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN
-        rule = (setup_1 | setup_2).match_setup_rule(100, box_type=box_type_2)
+        rule = (setup_1 | setup_2).match_setup_rule(100, 1, box_type=box_type_2)
         # THEN
         self.assertEqual(rule, setup_2_rule_1)
 
@@ -401,7 +401,7 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN
-        rule = (setup_1 | setup_2).match_setup_rule(100, box_type=box_type_2)
+        rule = (setup_1 | setup_2).match_setup_rule(100, 1, box_type=box_type_2)
         # THEN
         self.assertEqual(rule, setup_1_rule_1)
 
@@ -446,7 +446,9 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN
-        rule = (setup_1 | setup_2).match_setup_rule(100, component_type='lid_greyboard')
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, 1, component_type='lid_greyboard'
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_2)
 
@@ -490,6 +492,8 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
             ]
         )
         # WHEN
-        rule = (setup_1 | setup_2).match_setup_rule(100, component_type='lid_greyboard')
+        rule = (setup_1 | setup_2).match_setup_rule(
+            100, 1, component_type='lid_greyboard'
+        )
         # THEN
         self.assertEqual(rule, setup_1_rule_2)

--- a/package_configurator/tests/test_package_box_match_setup_rule.py
+++ b/package_configurator/tests/test_package_box_match_setup_rule.py
@@ -8,12 +8,12 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                 },
             ],
         )
@@ -57,12 +57,12 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                 },
             ],
         )
@@ -110,13 +110,13 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'min_layout_length': 200,
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'min_layout_length': 100,
                 },
             ],
@@ -151,13 +151,13 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'max_layout_length': 200,
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'max_layout_length': 100,
                 },
             ],
@@ -192,13 +192,13 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'min_layout_width': 200,
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'min_layout_width': 100,
                 },
             ],
@@ -233,13 +233,13 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'max_layout_width': 200,
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'max_layout_width': 100,
                 },
             ],
@@ -274,16 +274,16 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'min_layout_width': 100,
                     'max_layout_width': 150,
                     'min_layout_length': 200,
                     'max_layout_length': 250,
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'min_layout_width': 50,
                     'max_layout_width': 100,
                     'min_layout_length': 150,
@@ -315,16 +315,16 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'min_layout_width': 100,
                     'max_layout_width': 150,
                     'min_layout_length': 200,
                     'max_layout_length': 250,
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'min_layout_width': 50,
                     'max_layout_width': 100,
                     'min_layout_length': 150,
@@ -353,13 +353,13 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'box_type_ids': [(4, box_type_1.id)],
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'box_type_ids': [(4, box_type_2.id)],
                 },
             ],
@@ -383,13 +383,13 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'box_type_ids': [(4, box_type_1.id), (4, box_type_2.id)],
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'box_type_ids': [(4, box_type_2.id)],
                 },
             ],
@@ -410,12 +410,12 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                 },
             ],
         )
@@ -457,12 +457,12 @@ class TestPackageBoxMatchSetupRule(common.TestProductPackageConfiguratorCommon):
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                 },
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                 },
             ],
         )

--- a/package_configurator/tests/test_package_box_setup_rule_qty.py
+++ b/package_configurator/tests/test_package_box_setup_rule_qty.py
@@ -1,0 +1,131 @@
+from . import common
+
+
+class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
+    def test_01_box_setup_rule_qty_fixed(self):
+        # GIVEN
+        setup_1 = self.PackageBoxSetup.create(
+            {
+                'name': 'MY-BOX-SHEET-SETUP-1',
+                'setup_type': 'sheet',
+                'setup_qty_mode': 'fixed',
+            }
+        )
+        rules = self.PackageBoxSetupRule.create(
+            [
+                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_qty': 200},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 100},
+            ]
+        )
+        setup_1_rule_1 = rules[0]
+        setup_1_rule_2 = rules[1]
+        # WHEN min_qty is bare minimum
+        qty = setup_1_rule_2.calc_setup_qty(1000)
+        # THEN
+        self.assertEqual(qty, 100)
+        # WHEN min_qty is bare between two rules
+        qty = setup_1_rule_2.calc_setup_qty(1400)
+        # THEN
+        self.assertEqual(qty, 100)
+        # WHEN min_qty is bare minimum on first rule
+        qty = setup_1_rule_1.calc_setup_qty(2000)
+        # THEN
+        self.assertEqual(qty, 200)
+        # WHEN min_qty is over bare minimum on first rule
+        qty = setup_1_rule_1.calc_setup_qty(5000)
+        # THEN
+        self.assertEqual(qty, 200)
+
+    def test_02_box_setup_rule_qty_rel(self):
+        # GIVEN
+        setup_1 = self.PackageBoxSetup.create(
+            {
+                'name': 'MY-BOX-SHEET-SETUP-1',
+                'setup_type': 'sheet',
+                'setup_qty_mode': 'relative',
+            }
+        )
+        rules = self.PackageBoxSetupRule.create(
+            [
+                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_qty': 200},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 100},
+            ]
+        )
+        setup_1_rule_1 = rules[0]
+        setup_1_rule_2 = rules[1]
+        # WHEN min_qty is bare minimum
+        qty = setup_1_rule_2.calc_setup_qty(1000)
+        # THEN
+        self.assertEqual(qty, 100)
+        # WHEN min_qty is bare between two rules
+        qty = setup_1_rule_2.calc_setup_qty(1400)
+        # THEN
+        self.assertEqual(qty, 140)
+        # WHEN min_qty is bare minimum on first rule
+        qty = setup_1_rule_1.calc_setup_qty(2000)
+        # THEN
+        self.assertEqual(qty, 200)
+        # WHEN min_qty is over bare minimum on first rule
+        qty = setup_1_rule_1.calc_setup_qty(5000)
+        # THEN
+        self.assertEqual(qty, 200)
+
+    def test_03_box_setup_rule_qty_rel_uneven(self):
+        # GIVEN
+        setup_1 = self.PackageBoxSetup.create(
+            {
+                'name': 'MY-BOX-SHEET-SETUP-1',
+                'setup_type': 'sheet',
+                'setup_qty_mode': 'relative',
+            }
+        )
+        rules = self.PackageBoxSetupRule.create(
+            [
+                {'setup_id': setup_1.id, 'min_qty': 1700, 'setup_qty': 251},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 90},
+            ]
+        )
+        setup_1_rule_1 = rules[0]
+        setup_1_rule_2 = rules[1]
+        # WHEN min_qty is bare minimum
+        qty = setup_1_rule_2.calc_setup_qty(1000)
+        # THEN
+        self.assertEqual(qty, 90)
+        # WHEN min_qty is bare between two rules
+        qty = setup_1_rule_2.calc_setup_qty(1401)
+        # THEN
+        # It is ceiled up!
+        self.assertEqual(qty, 183)
+        # WHEN min_qty is bare minimum on first rule
+        qty = setup_1_rule_1.calc_setup_qty(1700)
+        # THEN
+        self.assertEqual(qty, 251)
+        # WHEN min_qty is over bare minimum on first rule
+        qty = setup_1_rule_1.calc_setup_qty(5000)
+        # THEN
+        self.assertEqual(qty, 251)
+
+    def test_04_box_setup_rule_qty_rel_invalid(self):
+        # GIVEN
+        setup_1 = self.PackageBoxSetup.create(
+            {
+                'name': 'MY-BOX-SHEET-SETUP-1',
+                'setup_type': 'sheet',
+                'setup_qty_mode': 'relative',
+            }
+        )
+        rules = self.PackageBoxSetupRule.create(
+            [
+                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_qty': 200},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 100},
+            ]
+        )
+        setup_1_rule_2 = rules[1]
+        # WHEN min_qty is below bare minimum
+        qty = setup_1_rule_2.calc_setup_qty(500)
+        # THEN
+        self.assertEqual(qty, 100)
+        # WHEN min_qty is over max.
+        qty = setup_1_rule_2.calc_setup_qty(5000)
+        # THEN
+        self.assertEqual(qty, 200)

--- a/package_configurator/tests/test_package_box_setup_rule_qty.py
+++ b/package_configurator/tests/test_package_box_setup_rule_qty.py
@@ -13,8 +13,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         )
         rules = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_qty': 200},
-                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_fixed_qty': 200},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_fixed_qty': 100},
             ]
         )
         setup_1_rule_1 = rules[0]
@@ -47,8 +47,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         )
         rules = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_qty': 200},
-                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_fixed_qty': 200},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_fixed_qty': 100},
             ]
         )
         setup_1_rule_1 = rules[0]
@@ -81,8 +81,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         )
         rules = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1700, 'setup_qty': 251},
-                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 90},
+                {'setup_id': setup_1.id, 'min_qty': 1700, 'setup_fixed_qty': 251},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_fixed_qty': 90},
             ]
         )
         setup_1_rule_1 = rules[0]
@@ -116,8 +116,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         )
         rules = self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_qty': 200},
-                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 2000, 'setup_fixed_qty': 200},
+                {'setup_id': setup_1.id, 'min_qty': 1000, 'setup_fixed_qty': 100},
             ]
         )
         setup_1_rule_2 = rules[1]

--- a/package_configurator/tests/test_package_box_setup_rule_qty.py
+++ b/package_configurator/tests/test_package_box_setup_rule_qty.py
@@ -6,8 +6,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         # GIVEN
         setup_1 = self.PackageBoxSetup.create(
             {
-                'name': 'MY-BOX-SHEET-SETUP-1',
-                'setup_type': 'sheet',
+                'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                'setup_type': 'production',
                 'setup_qty_mode': 'fixed',
             }
         )
@@ -40,8 +40,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         # GIVEN
         setup_1 = self.PackageBoxSetup.create(
             {
-                'name': 'MY-BOX-SHEET-SETUP-1',
-                'setup_type': 'sheet',
+                'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                'setup_type': 'production',
                 'setup_qty_mode': 'relative',
             }
         )
@@ -74,8 +74,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         # GIVEN
         setup_1 = self.PackageBoxSetup.create(
             {
-                'name': 'MY-BOX-SHEET-SETUP-1',
-                'setup_type': 'sheet',
+                'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                'setup_type': 'production',
                 'setup_qty_mode': 'relative',
             }
         )
@@ -109,8 +109,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         # GIVEN
         setup_1 = self.PackageBoxSetup.create(
             {
-                'name': 'MY-BOX-SHEET-SETUP-1',
-                'setup_type': 'sheet',
+                'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                'setup_type': 'production',
                 'setup_qty_mode': 'relative',
             }
         )
@@ -135,8 +135,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         # GIVEN
         setup = self.PackageBoxSetup.create(
             {
-                'name': 'MY-BOX-SHEET-SETUP-1',
-                'setup_type': 'sheet',
+                'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                'setup_type': 'production',
                 'inp_qty_measure': 'box',
             }
         )
@@ -149,8 +149,8 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         # GIVEN
         setup = self.PackageBoxSetup.create(
             {
-                'name': 'MY-BOX-SHEET-SETUP-1',
-                'setup_type': 'sheet',
+                'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                'setup_type': 'production',
                 # Raw Sheets
                 'inp_qty_measure': 'raw_sheet',
             }

--- a/package_configurator/tests/test_package_box_setup_rule_qty.py
+++ b/package_configurator/tests/test_package_box_setup_rule_qty.py
@@ -129,3 +129,33 @@ class TestPackageBoxSetupRuleQty(common.TestProductPackageConfiguratorCommon):
         qty = setup_1_rule_2.calc_setup_qty(5000)
         # THEN
         self.assertEqual(qty, 200)
+
+    # TODO: create TestPackageBoxSetupRule class and move these tests.
+    def test_05_box_setup_inp_qty_measure_box(self):
+        # GIVEN
+        setup = self.PackageBoxSetup.create(
+            {
+                'name': 'MY-BOX-SHEET-SETUP-1',
+                'setup_type': 'sheet',
+                'inp_qty_measure': 'box',
+            }
+        )
+        # WHEN
+        inp_qty = setup.convert_inp_qty(200, 27)
+        # THEN
+        self.assertEqual(inp_qty, 200)
+
+    def test_06_box_setup_inp_qty_measure_raw(self):
+        # GIVEN
+        setup = self.PackageBoxSetup.create(
+            {
+                'name': 'MY-BOX-SHEET-SETUP-1',
+                'setup_type': 'sheet',
+                # Raw Sheets
+                'inp_qty_measure': 'raw_sheet',
+            }
+        )
+        # WHEN
+        inp_qty = setup.convert_inp_qty(200, 27)
+        # THEN
+        self.assertEqual(inp_qty, 8)

--- a/package_configurator/tests/test_package_configurator_box_setup.py
+++ b/package_configurator/tests/test_package_configurator_box_setup.py
@@ -34,9 +34,9 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         setup_1_rule_1, setup_2_rule_1 = self.PackageBoxSetupRule.create(
             [
                 # To be used for first circulation
-                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_fixed_qty': 100},
                 # To be used for second circulation
-                {'setup_id': setup_2.id, 'min_qty': 150, 'setup_qty': 200},
+                {'setup_id': setup_2.id, 'min_qty': 150, 'setup_fixed_qty': 200},
             ]
         )
         cfg = self.PackageConfiguratorBox.create(
@@ -168,7 +168,7 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         circ_items = circulation_2.item_ids
         self.assertEqual(len(circ_items), 6)
         self.assertEqual(len(circ_items.mapped('circulation_setup_ids')), 6)
-        # setup_qty is 200 and fit qty is 27, so 200/27
+        # setup_fixed_qty is 200 and fit qty is 27, so 200/27
         item_base_greyboard = circ_items.filtered(
             lambda r: r.component_id.component_type == 'base_greyboard'
         )
@@ -245,11 +245,11 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         self.PackageBoxSetupRule.create(
             [
                 # To be used for first circulation
-                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_fixed_qty': 100},
                 # To be used for second circulation
-                {'setup_id': setup_2.id, 'min_qty': 150, 'setup_qty': 200},
+                {'setup_id': setup_2.id, 'min_qty': 150, 'setup_fixed_qty': 200},
                 # This is expected to be ignored, because printing house is not selected
-                {'setup_id': setup_print.id, 'min_qty': 1, 'setup_qty': 1000},
+                {'setup_id': setup_print.id, 'min_qty': 1, 'setup_fixed_qty': 1000},
             ]
         )
         cfg = self.PackageConfiguratorBox.create(
@@ -360,9 +360,9 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         self.PackageBoxSetupRule.create(
             [
                 # To be used for first circulation
-                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_fixed_qty': 100},
                 # To be used for second circulation
-                {'setup_id': setup_2.id, 'min_qty': 150, 'setup_qty': 200},
+                {'setup_id': setup_2.id, 'min_qty': 150, 'setup_fixed_qty': 200},
             ]
         )
         cfg = self.PackageConfiguratorBox.create(
@@ -474,8 +474,8 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         )
         self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 100},
-                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 100},
+                {'setup_id': setup_2.id, 'min_qty': 1, 'setup_fixed_qty': 100},
             ]
         )
         cfg = self.PackageConfiguratorBox.create(
@@ -562,7 +562,7 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         )
         self.PackageBoxSetupRule.create(
             [
-                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 100},
             ]
         )
         cfg = self.PackageConfiguratorBox.create(

--- a/package_configurator/tests/test_package_configurator_box_setup.py
+++ b/package_configurator/tests/test_package_configurator_box_setup.py
@@ -613,14 +613,14 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         self.assertEqual(len(circ_items), 2)
         self.assertEqual(len(circ_items.mapped('circulation_setup_ids')), 0)
 
-    def test_06_configure_box_do_setup_measure_by_raw(self):
+    def test_06_configure_box_do_setup_qty_measure_raw(self):
         # GIVEN
         setup_1 = self.PackageBoxSetup.create(
             [
                 {
                     'name': 'MY-BOX-SHEET-SETUP-1',
                     'setup_type': 'sheet',
-                    'setup_qty_measure': 'raw',
+                    'setup_qty_measure': 'raw_sheet',
                     'sequence': 20,
                 },
             ],
@@ -675,3 +675,71 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         # on setup_fixed_qty!
         self.assertEqual(item_base_greyboard.circulation_setup_ids.setup_raw_qty, 100)
         self.assertEqual(item_base_greyboard.quantity, 104)
+
+    def test_07_configure_box_do_setup_inp_qty_measure_raw(self):
+        # GIVEN
+        setup_1 = self.PackageBoxSetup.create(
+            [
+                {
+                    'name': 'MY-BOX-SHEET-SETUP-1',
+                    'setup_type': 'sheet',
+                    'setup_qty_measure': 'raw_sheet',
+                    'inp_qty_measure': 'raw_sheet',
+                    'sequence': 20,
+                },
+            ],
+        )
+        rule_1, rule_2 = self.PackageBoxSetupRule.create(
+            [
+                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_fixed_qty': 100},
+                {'setup_id': setup_1.id, 'min_qty': 1, 'setup_fixed_qty': 200},
+            ]
+        )
+        cfg = self.PackageConfiguratorBox.create(
+            {
+                'box_type_id': self.package_box_type_1.id,
+                'base_length': 165,
+                'base_width': 42,
+                'base_height': 14.5,
+                'lid_height': 16,
+                'lid_extra': 2.0,
+                'outside_wrapping_extra': 20.0,
+            }
+        )
+        (comp_base_greyboard,) = self.PackageConfiguratorBoxComponent.create(
+            [
+                {
+                    'component_type': 'base_greyboard',
+                    'sheet_id': self.package_sheet_greyboard_1.id,
+                    'configurator_id': cfg.id,
+                },
+            ]
+        )
+        circulation_1 = self.PackageConfiguratorBoxCirculation.create(
+            [
+                {'quantity': 100, 'configurator_id': cfg.id},
+            ]
+        )
+        # WHEN
+        cfg.action_setup()
+        # THEN
+        # Quantities
+        # Circulations
+        # With 100 box circulation
+        # Setup
+        circ_items = circulation_1.item_ids
+        self.assertEqual(len(circ_items), 1)
+        # One setup per component.
+        self.assertEqual(len(circ_items.mapped('circulation_setup_ids')), 1)
+        item_base_greyboard = circ_items.filtered(
+            lambda r: r.component_id.component_type == 'base_greyboard'
+        )
+        # With raw measure, there is no conversion, we simply calculate what is
+        # on setup_fixed_qty!
+        self.assertEqual(item_base_greyboard.circulation_setup_ids.setup_raw_qty, 200)
+        # Second rule is to be created, because 100 boxes of quantity is 4 raw sheets,
+        # so we don't satisfy minimum quantity of 50 (when measured by raw sheets).
+        self.assertEqual(
+            item_base_greyboard.circulation_setup_ids.setup_rule_id, rule_2
+        )
+        self.assertEqual(item_base_greyboard.quantity, 204)

--- a/package_configurator/tests/test_package_configurator_box_setup.py
+++ b/package_configurator/tests/test_package_configurator_box_setup.py
@@ -612,3 +612,66 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         circ_items = circulation_2.item_ids
         self.assertEqual(len(circ_items), 2)
         self.assertEqual(len(circ_items.mapped('circulation_setup_ids')), 0)
+
+    def test_06_configure_box_do_setup_measure_by_raw(self):
+        # GIVEN
+        setup_1 = self.PackageBoxSetup.create(
+            [
+                {
+                    'name': 'MY-BOX-SHEET-SETUP-1',
+                    'setup_type': 'sheet',
+                    'setup_qty_measure': 'raw',
+                    'sequence': 20,
+                },
+            ],
+        )
+        self.PackageBoxSetupRule.create(
+            [
+                {'setup_id': setup_1.id, 'min_qty': 50, 'setup_fixed_qty': 100},
+            ]
+        )
+        cfg = self.PackageConfiguratorBox.create(
+            {
+                'box_type_id': self.package_box_type_1.id,
+                'base_length': 165,
+                'base_width': 42,
+                'base_height': 14.5,
+                'lid_height': 16,
+                'lid_extra': 2.0,
+                'outside_wrapping_extra': 20.0,
+            }
+        )
+        (comp_base_greyboard,) = self.PackageConfiguratorBoxComponent.create(
+            [
+                {
+                    'component_type': 'base_greyboard',
+                    'sheet_id': self.package_sheet_greyboard_1.id,
+                    'configurator_id': cfg.id,
+                },
+            ]
+        )
+        circulation_1 = self.PackageConfiguratorBoxCirculation.create(
+            [
+                {'quantity': 100, 'configurator_id': cfg.id},
+            ]
+        )
+        # WHEN
+        cfg.action_setup()
+        # THEN
+        # Quantities
+        # grey board layout is 1000x700 (mm)
+        self.assertEqual(comp_base_greyboard.fit_qty, 27)
+        # Circulations
+        # With 100 box circulation
+        # Setup
+        circ_items = circulation_1.item_ids
+        self.assertEqual(len(circ_items), 1)
+        # One setup per component.
+        self.assertEqual(len(circ_items.mapped('circulation_setup_ids')), 1)
+        item_base_greyboard = circ_items.filtered(
+            lambda r: r.component_id.component_type == 'base_greyboard'
+        )
+        # With raw measure, there is no conversion, we simply calculate what is
+        # on setup_fixed_qty!
+        self.assertEqual(item_base_greyboard.circulation_setup_ids.setup_raw_qty, 100)
+        self.assertEqual(item_base_greyboard.quantity, 104)

--- a/package_configurator/tests/test_package_configurator_box_setup.py
+++ b/package_configurator/tests/test_package_configurator_box_setup.py
@@ -19,14 +19,14 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'sequence': 20,
                 },
                 # To try matching this first!
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': 'production',
                     'sequence': 10,
                 },
             ],
@@ -225,14 +225,14 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         setup_1, setup_2, setup_print = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': const.SetupType.SHEET,
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': const.SetupType.PRODUCTION,
                     'sequence': 20,
                 },
                 # To try matching this first!
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-2',
-                    'setup_type': const.SetupType.SHEET,
+                    'name': 'MY-BOX-PRODUCTION-SETUP-2',
+                    'setup_type': const.SetupType.PRODUCTION,
                     'sequence': 10,
                 },
                 {
@@ -461,8 +461,8 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         setup_1, setup_2 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': const.SetupType.SHEET,
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': const.SetupType.PRODUCTION,
                     'sequence': 10,
                 },
                 {
@@ -618,8 +618,8 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         setup_1 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'setup_qty_measure': 'raw_sheet',
                     'sequence': 20,
                 },
@@ -681,8 +681,8 @@ class TestPackageConfiguratorBoxSetup(common.TestProductPackageConfiguratorCommo
         setup_1 = self.PackageBoxSetup.create(
             [
                 {
-                    'name': 'MY-BOX-SHEET-SETUP-1',
-                    'setup_type': 'sheet',
+                    'name': 'MY-BOX-PRODUCTION-SETUP-1',
+                    'setup_type': 'production',
                     'setup_qty_measure': 'raw_sheet',
                     'inp_qty_measure': 'raw_sheet',
                     'sequence': 20,

--- a/package_configurator/tests/test_package_sheet_usable_dimensions.py
+++ b/package_configurator/tests/test_package_sheet_usable_dimensions.py
@@ -7,6 +7,7 @@ class TestPackageSheetUsableDimensions(common.TestProductPackageConfiguratorComm
         super().setUpClass()
         cls.package_box_type_1 = cls.PackageBoxType.create({'name': 'MY-BOX-TYPE-1'})
         cls.print_house_1 = cls.PackagePrintHouse.create({'name': 'MY-PRINT-HOUSE-1'})
+        cls.print_color_1 = cls.PackagePrintColor.create({'name': 'Color 1'})
 
     def test_01_sheet_usable_dimensions_no_print_house(self):
         # GIVEN
@@ -28,6 +29,7 @@ class TestPackageSheetUsableDimensions(common.TestProductPackageConfiguratorComm
                 'component_type': 'base_greyboard',
                 'sheet_id': self.package_sheet_greyboard_1.id,
                 'configurator_id': cfg.id,
+                'print_color_id': self.print_color_1.id,
             },
         )
         # THEN
@@ -56,13 +58,43 @@ class TestPackageSheetUsableDimensions(common.TestProductPackageConfiguratorComm
                 'component_type': 'base_greyboard',
                 'sheet_id': self.package_sheet_greyboard_1.id,
                 'configurator_id': cfg.id,
+                'print_color_id': self.print_color_1.id,
             },
         )
         # THEN
         self.assertEqual(comp_base_greyboard.sheet_usable_length, 900)
         self.assertEqual(comp_base_greyboard.sheet_usable_width, 600)
 
-    def test_03_sheet_usable_dimensions_print_house_higher_dimensions(self):
+    def test_03_sheet_usable_dimensions_print_house_lower_dimensions_no_color(self):
+        # GIVEN
+        self.package_sheet_greyboard_1.write({'sheet_length': 1000, 'sheet_width': 700})
+        self.print_house_1.write({'print_max_length': 900, 'print_max_width': 600})
+        # WHEN
+        cfg = self.PackageConfiguratorBox.create(
+            {
+                'box_type_id': self.package_box_type_1.id,
+                'base_length': 165,
+                'base_width': 42,
+                'base_height': 14.5,
+                'lid_height': 16,
+                'lid_extra': 2.0,
+                'outside_wrapping_extra': 20.0,
+                'print_house_id': self.print_house_1.id,
+            },
+        )
+        comp_base_greyboard = self.PackageConfiguratorBoxComponent.create(
+            {
+                'component_type': 'base_greyboard',
+                'sheet_id': self.package_sheet_greyboard_1.id,
+                'configurator_id': cfg.id,
+                'print_color_id': False,
+            },
+        )
+        # THEN
+        self.assertEqual(comp_base_greyboard.sheet_usable_length, 1000)
+        self.assertEqual(comp_base_greyboard.sheet_usable_width, 700)
+
+    def test_04_sheet_usable_dimensions_print_house_higher_dimensions(self):
         # GIVEN
         self.package_sheet_greyboard_1.write({'sheet_length': 1000, 'sheet_width': 700})
         self.print_house_1.write({'print_max_length': 1200, 'print_max_width': 800})
@@ -84,13 +116,14 @@ class TestPackageSheetUsableDimensions(common.TestProductPackageConfiguratorComm
                 'component_type': 'base_greyboard',
                 'sheet_id': self.package_sheet_greyboard_1.id,
                 'configurator_id': cfg.id,
+                'print_color_id': self.print_color_1.id,
             },
         )
         # THEN
         self.assertEqual(comp_base_greyboard.sheet_usable_length, 1000)
         self.assertEqual(comp_base_greyboard.sheet_usable_width, 700)
 
-    def test_04_sheet_usable_dimensions_print_house_higher_no_limit(self):
+    def test_05_sheet_usable_dimensions_print_house_higher_no_limit(self):
         # GIVEN
         self.package_sheet_greyboard_1.write({'sheet_length': 1000, 'sheet_width': 700})
         self.print_house_1.write({'print_max_length': 0, 'print_max_width': 0})
@@ -112,6 +145,7 @@ class TestPackageSheetUsableDimensions(common.TestProductPackageConfiguratorComm
                 'component_type': 'base_greyboard',
                 'sheet_id': self.package_sheet_greyboard_1.id,
                 'configurator_id': cfg.id,
+                'print_color_id': self.print_color_1.id,
             },
         )
         # THEN

--- a/package_configurator/views/menus.xml
+++ b/package_configurator/views/menus.xml
@@ -83,8 +83,8 @@
             />
             <menuitem id="package_box_setup_menu" name="Setups" sequence="40">
                 <menuitem
-                    id="package_box_setup_sheet_menu"
-                    action="package_box_setup_sheet_action"
+                    id="package_box_setup_production_menu"
+                    action="package_box_setup_production_action"
                     sequence="5"
                 />
                 <menuitem

--- a/package_configurator/views/package_box_setup.xml
+++ b/package_configurator/views/package_box_setup.xml
@@ -7,6 +7,7 @@
             <tree>
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
+                <field name="setup_qty_mode" optional="show"/>
                 <field name="setup_type" optional="hide"/>
             </tree>
         </field>
@@ -21,6 +22,7 @@
                     <group name="general" string="General">
                         <group name="left">
                             <field name="name"/>
+                            <field name="setup_qty_mode"/>
                             <field name="setup_type" invisible="1"/>
                             <field name="active" widget="boolean_toggle"/>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/package_configurator/views/package_box_setup.xml
+++ b/package_configurator/views/package_box_setup.xml
@@ -40,6 +40,10 @@
                             <field name="rule_ids">
                                 <tree editable="bottom">
                                     <field name="min_qty"/>
+                                    <field
+                                        name="component_type"
+                                        column_invisible="parent.setup_type != 'sheet'"
+                                    />
                                     <field name="setup_fixed_qty"/>
                                 </tree>
                             </field>

--- a/package_configurator/views/package_box_setup.xml
+++ b/package_configurator/views/package_box_setup.xml
@@ -9,6 +9,7 @@
                 <field name="name"/>
                 <field name="setup_qty_mode" optional="show"/>
                 <field name="setup_qty_measure" optional="show"/>
+                <field name="inp_qty_measure" optional="show"/>
                 <field name="setup_type" optional="hide"/>
             </tree>
         </field>
@@ -25,6 +26,7 @@
                             <field name="name"/>
                             <field name="setup_qty_mode"/>
                             <field name="setup_qty_measure"/>
+                            <field name="inp_qty_measure"/>
                             <field name="setup_type" invisible="1"/>
                             <field name="active" widget="boolean_toggle"/>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/package_configurator/views/package_box_setup.xml
+++ b/package_configurator/views/package_box_setup.xml
@@ -46,7 +46,7 @@
                                     <field name="min_qty"/>
                                     <field
                                         name="component_type"
-                                        column_invisible="parent.setup_type != 'sheet'"
+                                        column_invisible="parent.setup_type != 'production'"
                                     />
                                     <field name="setup_fixed_qty"/>
                                 </tree>
@@ -58,12 +58,12 @@
         </field>
     </record>
 
-    <record id="package_box_setup_sheet_action" model="ir.actions.act_window">
-        <field name="name">Sheets Setup</field>
+    <record id="package_box_setup_production_action" model="ir.actions.act_window">
+        <field name="name">Productions Setup</field>
         <field name="res_model">package.box.setup</field>
         <field name="view_mode">tree,form</field>
-        <field name="domain">[('setup_type', '=', 'sheet')]</field>
-        <field name="context">{'default_setup_type': 'sheet'}</field>
+        <field name="domain">[('setup_type', '=', 'production')]</field>
+        <field name="context">{'default_setup_type': 'production'}</field>
     </record>
     <record id="package_box_setup_print_action" model="ir.actions.act_window">
         <field name="name">Prints Setup</field>

--- a/package_configurator/views/package_box_setup.xml
+++ b/package_configurator/views/package_box_setup.xml
@@ -8,6 +8,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="setup_qty_mode" optional="show"/>
+                <field name="setup_qty_measure" optional="show"/>
                 <field name="setup_type" optional="hide"/>
             </tree>
         </field>
@@ -23,6 +24,7 @@
                         <group name="left">
                             <field name="name"/>
                             <field name="setup_qty_mode"/>
+                            <field name="setup_qty_measure"/>
                             <field name="setup_type" invisible="1"/>
                             <field name="active" widget="boolean_toggle"/>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/package_configurator/views/package_box_setup.xml
+++ b/package_configurator/views/package_box_setup.xml
@@ -40,7 +40,7 @@
                             <field name="rule_ids">
                                 <tree editable="bottom">
                                     <field name="min_qty"/>
-                                    <field name="setup_qty"/>
+                                    <field name="setup_fixed_qty"/>
                                 </tree>
                             </field>
                         </page>


### PR DESCRIPTION
Now it is possible to calculate setup quantity in two modes:

* fixed: as before, simply use setup_qty defined (to be setup_fixed_qty)
* relative: relative quantity to greater rule, so setup quantity would proportionally increase the closed it gets to greater rule.