### PR TITLE
[FIX] procurement_group_parent_root: self group

### DIFF
--- a/procurement_group_parent_root/__manifest__.py
+++ b/procurement_group_parent_root/__manifest__.py
@@ -2,7 +2,7 @@
 # See LICENSE and COPYRIGHT files for details.
 {
     "name": "Procurement Group - Parent Root",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "summary": "Compute root parent group for each procurement group",
     "license": "LGPL-3",
     "author": "Andrius Laukavičius",


### PR DESCRIPTION
Apparently self related move can expose procurement group to be itself, so it would end up with infinite loop. To make sure that won't happen, we explicitly exclude it when looking for parent procurement group.

Now after having this fixed, it should be possible to compute root procurement group on install as well.