### PR TITLE
[18.0][MIG] product_code_uniqueness: migration to 18.0

### DIFF
--- a/product_code_uniqueness/README.rst
+++ b/product_code_uniqueness/README.rst
@@ -24,3 +24,4 @@ Contributors
 ============
 
 * Andrius Laukavičius (timefordev)
+* Ugnė Sinkevičienė (ugne@versada.eu)

--- a/product_code_uniqueness/__manifest__.py
+++ b/product_code_uniqueness/__manifest__.py
@@ -2,7 +2,7 @@
 # See LICENSE file for full copyright and licensing details.
 {
     'name': "Unique Product Code",
-    'version': '17.0.1.0.0',
+    'version': '18.0.1.0.0',
     'summary': 'product, code, unique',
     'license': 'LGPL-3',
     'author': "Andrius Laukavičius",
@@ -15,5 +15,5 @@
     'data': [
         'views/res_config_settings_views.xml',
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/product_code_uniqueness/i18n/lt.po
+++ b/product_code_uniqueness/i18n/lt.po
@@ -1,13 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#   * product_code_uniquess
+# 	* product_code_uniqueness
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-19 07:38+0000\n"
-"PO-Revision-Date: 2024-05-19 07:38+0000\n"
+"POT-Creation-Date: 2025-01-22 08:44+0000\n"
+"PO-Revision-Date: 2025-01-22 08:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,7 +18,6 @@ msgstr ""
 #. module: product_code_uniqueness
 #. odoo-python
 #: code:addons/product_code_uniqueness/utils.py:0
-#, python-format
 msgid " (copy)"
 msgstr " (kopija)"
 
@@ -74,7 +73,6 @@ msgstr "Produkto variantas"
 #. module: product_code_uniqueness
 #. odoo-python
 #: code:addons/product_code_uniqueness/models/product_product.py:0
-#, python-format
 msgid ""
 "Product code (%s) must be unique per company! There might be an archived "
 "product with the same code too."

--- a/product_code_uniqueness/models/product_product.py
+++ b/product_code_uniqueness/models/product_product.py
@@ -1,4 +1,4 @@
-from odoo import _, api, models
+from odoo import api, models
 from odoo.exceptions import ValidationError
 
 from ..utils import build_default_code, search_multicompany_count
@@ -14,7 +14,12 @@ class ProductProduct(models.Model):
 
     def copy_data(self, default=None):
         """Extend to copy `default_code` with ' (copy)' extension."""
-        return super().copy_data(build_default_code(self, default))
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'default_code' not in default:
+            for template, vals in zip(self, vals_list):
+                vals['default_code'] = build_default_code(template, default=default)
+        return vals_list
 
     @api.constrains('default_code', 'company_id')
     def _check_default_code(self):
@@ -46,7 +51,7 @@ class ProductProduct(models.Model):
                 )
                 if matches > 1:
                     raise ValidationError(
-                        _(
+                        self.env._(
                             "Product code (%s) must be unique per company! "
                             "There might be an archived product with the "
                             "same code too.",

--- a/product_code_uniqueness/models/product_template.py
+++ b/product_code_uniqueness/models/product_template.py
@@ -17,4 +17,9 @@ class ProductTemplate(models.Model):
 
     def copy_data(self, default=None):
         """Extend to copy `default_code` with ' (copy)' extension."""
-        return super().copy_data(build_default_code(self, default))
+        default = dict(default or {})
+        vals_list = super().copy_data(default=default)
+        if 'default_code' not in default:
+            for template, vals in zip(self, vals_list):
+                vals['default_code'] = build_default_code(template, default=default)
+        return vals_list

--- a/product_code_uniqueness/tests/common.py
+++ b/product_code_uniqueness/tests/common.py
@@ -10,11 +10,15 @@ class TestProductCommon(TransactionCase):
         super().setUpClass()
         cls.ResCompany = cls.env['res.company']
         cls.IrConfigParameter = cls.env['ir.config_parameter']
+        cls.ProductComboItem = cls.env['product.combo.item']
         cls.product_comp_rule = cls.env.ref('product.product_comp_rule')
         # Product code 'E-COM07'.
         cls.product_1 = cls.env.ref('product.product_product_6')
         # Product code 'FURN_7800'.
         cls.product_2 = cls.env.ref('product.product_product_3')
+        # Unlink product-related combos to prevent company-specific conflicts or inconsistencies.
+        cls.ProductComboItem.search([('product_id', 'in', cls.product_2.ids)]).unlink()
+        # By default, product's company is not set.
         cls.main_company_id = cls.env.ref('base.main_company').id
         cls.demo_company_id = cls.ResCompany.create({'name': "Demo Company"}).id
         # By default, product's company is not set.

--- a/product_code_uniqueness/tests/test_product_duplicate.py
+++ b/product_code_uniqueness/tests/test_product_duplicate.py
@@ -59,3 +59,17 @@ class TestProductDuplicate(common.TestProductCommon):
             False,
             "Product was not correctly duplicated!",
         )
+
+    def test_07_products_duplicate(self):
+        """Test case for copying multiple `product.product` records."""
+        product_1, product_2 = (self.product_1 + self.product_2).copy()
+        self.assertEqual(
+            product_1.default_code,
+            'E-COM07 (copy)',
+            "Product was not correctly duplicated!",
+        )
+        self.assertEqual(
+            product_2.default_code,
+            'FURN_7800 (copy)',
+            "Product was not correctly duplicated!",
+        )

--- a/product_code_uniqueness/utils.py
+++ b/product_code_uniqueness/utils.py
@@ -1,4 +1,3 @@
-from odoo import _
 from odoo.osv import expression
 
 # TODO: move these to more general module.
@@ -15,11 +14,8 @@ def build_default_code(obj, default):
     default_code = obj.default_code
     # Leave original default_code (False) if it is not set.
     if default_code:
-        if default is None:
-            default = {}
-        default.setdefault('default_code', default_code + _(" (copy)"))
-    return default
-
+        return default_code + obj.env._(" (copy)")
+    return False
 
 def search_multicompany(
     model_obj, domain, offset=0, limit=None, order=None, options=None


### PR DESCRIPTION
FYI, `copy` and `copy_data` now work on multiple records. This means that `copy_data` returns a list of values, and `self` may be a multi-recordset. Reference: https://github.com/odoo/odoo/pull/154132