### PR TITLE
[FIX] sale_component_sticker_info_mrp_purchase: qty

### DIFF
--- a/sale_component_sticker_info_mrp_purchase/models/purchase_order_line.py
+++ b/sale_component_sticker_info_mrp_purchase/models/purchase_order_line.py
@@ -26,7 +26,8 @@ class PurchaseOrderLine(models.Model):
         # We find MOs for products that are manufactured using
         # this PO line product (component)!
         mos = moves.group_id.mrp_production_ids
-        info = prepare_component_sticker_info(get_sale_mos(mos))
+        product = self.env['product.product'].browse(res.get('product_id'))
+        info = prepare_component_sticker_info(get_sale_mos(mos), product)
         if info:
             res['component_sticker_info'] = info
         return res

--- a/sale_component_sticker_info_mrp_purchase/tests/test_sale_group_name_mrp_purchase.py
+++ b/sale_component_sticker_info_mrp_purchase/tests/test_sale_group_name_mrp_purchase.py
@@ -46,7 +46,7 @@ class TestSaleGroupNameMrpPurchase(TransactionCase):
                 'product_tmpl_id': cls.product_1.product_tmpl_id.id,
                 'product_qty': 1,
                 'bom_line_ids': [
-                    (0, 0, {'product_id': cls.product_1_comp_1.id, 'product_qty': 1})
+                    (0, 0, {'product_id': cls.product_1_comp_1.id, 'product_qty': 2})
                 ],
             }
         )
@@ -75,7 +75,7 @@ class TestSaleGroupNameMrpPurchase(TransactionCase):
         self.assertEqual(mo.sale_group_name, 'A-1')
         self.assertEqual(
             purchase.order_line[0].component_sticker_info,
-            f'A-1, {self.sale_1.name} [QTY:1.0]',
+            f'A-1, {self.sale_1.name} [QTY:2.0]',
         )
 
     def test_02_so_group_name_mrp_po_linked_multi_line_w_packaging_name(self):
@@ -119,7 +119,7 @@ class TestSaleGroupNameMrpPurchase(TransactionCase):
         sale_name = self.sale_1.name
         self.assertEqual(
             purchase.order_line[0].component_sticker_info,
-            f'A-1, {pname}, {sale_name} [QTY:2.0]; A-2, {pname}, {sale_name} [QTY:1.0]',
+            f'A-1, {pname}, {sale_name} [QTY:4.0]; A-2, {pname}, {sale_name} [QTY:2.0]',
         )
 
     def test_03_so_group_name_2_level_mrp_po_linked_multi_line_w_packname(self):
@@ -158,11 +158,15 @@ class TestSaleGroupNameMrpPurchase(TransactionCase):
             [
                 {
                     'product_tmpl_id': product_main.product_tmpl_id.id,
-                    'bom_line_ids': [(0, 0, {'product_id': product_comp.id})],
+                    'bom_line_ids': [
+                        (0, 0, {'product_id': product_comp.id, 'product_qty': 2})
+                    ],
                 },
                 {
                     'product_tmpl_id': product_comp.product_tmpl_id.id,
-                    'bom_line_ids': [(0, 0, {'product_id': product_raw.id})],
+                    'bom_line_ids': [
+                        (0, 0, {'product_id': product_raw.id, 'product_qty': 3})
+                    ],
                 },
             ]
         )
@@ -211,7 +215,12 @@ class TestSaleGroupNameMrpPurchase(TransactionCase):
         sale_name = sale_1.name
         self.assertEqual(
             purchase.order_line[0].component_sticker_info,
-            f'A-1, {pname}, {sale_name} [QTY:2.0]; A-2, {pname}, {sale_name} [QTY:1.0]',
+            # 2 * 2 * 3 = 12
+            # 1 * 2 * 3 = 6
+            (
+                f'A-1, {pname}, {sale_name} [QTY:12.0]; A-2, '
+                + f'{pname}, {sale_name} [QTY:6.0]'
+            ),
         )
 
     def test_04_so_group_name_3_level_mrp_po_linked_multi_line_w_packname(self):
@@ -262,15 +271,21 @@ class TestSaleGroupNameMrpPurchase(TransactionCase):
             [
                 {
                     'product_tmpl_id': product_main.product_tmpl_id.id,
-                    'bom_line_ids': [(0, 0, {'product_id': product_comp.id})],
+                    'bom_line_ids': [
+                        (0, 0, {'product_id': product_comp.id, 'product_qty': 2})
+                    ],
                 },
                 {
                     'product_tmpl_id': product_comp.product_tmpl_id.id,
-                    'bom_line_ids': [(0, 0, {'product_id': product_sub_comp.id})],
+                    'bom_line_ids': [
+                        (0, 0, {'product_id': product_sub_comp.id, 'product_qty': 3})
+                    ],
                 },
                 {
                     'product_tmpl_id': product_sub_comp.product_tmpl_id.id,
-                    'bom_line_ids': [(0, 0, {'product_id': product_raw.id})],
+                    'bom_line_ids': [
+                        (0, 0, {'product_id': product_raw.id, 'product_qty': 4})
+                    ],
                 },
             ]
         )
@@ -324,5 +339,10 @@ class TestSaleGroupNameMrpPurchase(TransactionCase):
         sale_name = sale_1.name
         self.assertEqual(
             purchase.order_line[0].component_sticker_info,
-            f'A-1, {pname}, {sale_name} [QTY:2.0]; A-2, {pname}, {sale_name} [QTY:1.0]',
+            # 2 * 2 * 3 * 4 = 48
+            # 1 * 2 * 3 * 4 = 24
+            (
+                f'A-1, {pname}, {sale_name} [QTY:48.0]; A-2, '
+                + f'{pname}, {sale_name} [QTY:24.0]'
+            ),
         )

--- a/sale_component_sticker_info_mrp_purchase/utils.py
+++ b/sale_component_sticker_info_mrp_purchase/utils.py
@@ -34,21 +34,46 @@ def prepare_sale_group_name(sale_lines):
     return ', '.join(gn for gn in group_names)
 
 
-def prepare_component_sticker_info(mos):
+def prepare_component_sticker_info(mos, raw_product):
     infos = []
     for mo in mos:
         if mo.sale_group_name:
-            infos.append(_prepare_component_sticker_info(mo))
+            infos.append(_prepare_component_sticker_info(mo, raw_product))
     return f'{STICKER_INFO_SEP} '.join(infos)
 
 
-def _prepare_component_sticker_info(mo):
+def _prepare_component_sticker_info(mo, raw_product):
     product = mo.product_id
     info = mo.sale_group_name
     if product.packaging_name:
         info = f'{info}, {product.packaging_name}'
     if mo.origin:
         info = f'{info}, {mo.origin}'
-    if mo.product_qty:
-        info = f'{info} [QTY:{mo.product_qty}]'
+    qty = _gather_raw_product_quantity(mo, raw_product)
+    if qty:
+        info = f'{info} [QTY:{qty}]'
     return info
+
+
+def _gather_raw_product_quantity(mo, raw_product):
+    def filter_moves(product):
+        return lambda r: r.product_id == product
+
+    for descendant_mo in _get_descendant_mo(mo):
+        # We gather quantity from first matched MO in a chain.
+        moves = descendant_mo.move_raw_ids.filtered(filter_moves(raw_product))
+        if not moves:
+            continue
+        return sum(m.product_uom_qty for m in moves)
+    return 0.0
+
+
+def _get_descendant_mo(mo):
+    def get_child(mo):
+        child_mos = mo._get_children()
+        for child_mo in child_mos:
+            yield child_mo
+            yield from get_child(child_mo)
+
+    yield mo
+    yield from get_child(mo)


### PR DESCRIPTION
We had to find quantity for product that is used on purchase line, not the product that uses that product in manufacturing.