### PR TITLE
[IMP] delivery_3pl: sync carrier

### DIFF
--- a/delivery_3pl/model_services/tpl_sale_order.py
+++ b/delivery_3pl/model_services/tpl_sale_order.py
@@ -58,7 +58,12 @@ class TplSaleOrder(models.AbstractModel):
         if picking:
             picking.write(picking_vals)
             auto_finish_picking(picking, raise_exc=False)
-        sale.tpl_status = 'done'
+        sale_vals = {'tpl_status': 'done'}
+        picking_carrier = picking.carrier_id
+        if picking_carrier and sale.carrier_id != picking_carrier:
+            # Sync carrier.
+            sale_vals['carrier_id'] = picking_carrier.id
+        sale.write(sale_vals)
         invoice_3pl_order(sale)
         return True
 

--- a/delivery_3pl/models/tpl_service.py
+++ b/delivery_3pl/models/tpl_service.py
@@ -32,7 +32,9 @@ class TplService(models.Model):
         lambda s: s._get_integration_selection(),
         required=True,
     )
-    http_client_profile_id = fields.Many2one('http.client.profile', copy=False)
+    http_client_profile_id = fields.Many2one(
+        'http.client.profile', string="HTTP Client Profile", copy=False
+    )
     # Invoice/email management fields.
     invoice_state_target = fields.Selection(
         [('draft', 'Draft'), ('open', 'Open'), ('paid', 'Paid')],

--- a/delivery_3pl/views/tpl_service.xml
+++ b/delivery_3pl/views/tpl_service.xml
@@ -39,6 +39,10 @@
                                 name="warehouse_id"
                                 options="{'no_create_edit': True}"
                             />
+                            <field
+                                name="carrier_default_id"
+                                options="{'no_create_edit': True}"
+                            />
                         </group>
                         <group name="filters" string="Filters">
                             <field
@@ -47,6 +51,7 @@
                             />
                         </group>
                     </group>
+                    <notebook/>
                 </sheet>
             </form>
 


### PR DESCRIPTION
We now sync carrier from picking on sale if it was set during sync shipment event.

Also adding missing carrier_default_id on view as well as notebook tag entry to be able to extend it on tpl.service form.